### PR TITLE
Show a component preview on every tile of the components page

### DIFF
--- a/scripts/site-shots.mjs
+++ b/scripts/site-shots.mjs
@@ -37,6 +37,13 @@ export const SHOTS_URL_BASE = '/shots';
  */
 
 /**
+ * Byte offset one past the last IHDR field this file reads (the interlace
+ * method at offset 28). Every header read below is guarded against it, so a
+ * truncated file is rejected rather than throwing RangeError out of the build.
+ */
+const IHDR_END = 29;
+
+/**
  * Read a PNG's intrinsic size out of its IHDR chunk.
  *
  * A PNG is an 8-byte signature followed by IHDR, whose width and height are
@@ -47,7 +54,7 @@ export const SHOTS_URL_BASE = '/shots';
  * @returns {{ width: number, height: number } | null} null if not a PNG.
  */
 export function pngSize(buf) {
-  if (buf.length < 24) return null;
+  if (buf.length < IHDR_END) return null;
   // \x89PNG\r\n\x1a\n
   if (buf.readUInt32BE(0) !== 0x89504e47) return null;
   const width = buf.readUInt32BE(16);
@@ -80,6 +87,86 @@ const MIN_INK = 0.015;
 /** Channel value at or above which a pixel counts as paper rather than ink. */
 const WHITE = 240;
 
+/** Bytes per pixel for the one colour type decoded here (8-bit RGB). */
+const RGB_BPP = 3;
+
+/**
+ * Paeth predictor: of the three neighbouring bytes, the one the linear
+ * estimate `a + b - c` lands closest to.
+ *
+ * @param {number} a Byte to the left.
+ * @param {number} b Byte above.
+ * @param {number} c Byte above-left.
+ * @returns {number}
+ */
+function paeth(a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+/**
+ * Reconstruct one scanline in place, undoing its PNG filter.
+ *
+ * `line` arrives holding the filtered bytes and leaves holding the real ones.
+ * Each filter adds back a prediction from the byte to the left (a, already
+ * reconstructed this row), the byte above (b) and the byte above-left (c).
+ *
+ * @param {number} filter Filter type byte, 0-4.
+ * @param {Buffer} line Filtered bytes in, reconstructed bytes out.
+ * @param {Buffer} prev Previous reconstructed scanline.
+ * @returns {boolean} false if the filter type is unknown.
+ */
+function unfilterRow(filter, line, prev) {
+  if (filter < 0 || filter > 4) return false; // unknown filter — do not guess
+
+  for (let i = 0; i < line.length; i++) {
+    const a = i >= RGB_BPP ? line[i - RGB_BPP] : 0;
+    const b = prev[i];
+    const c = i >= RGB_BPP ? prev[i - RGB_BPP] : 0;
+    let add = 0;
+    if (filter === 1) add = a;
+    else if (filter === 2) add = b;
+    else if (filter === 3) add = (a + b) >> 1;
+    else if (filter === 4) add = paeth(a, b, c);
+    line[i] = (line[i] + add) & 0xff;
+  }
+  return true;
+}
+
+/**
+ * Concatenated contents of a PNG's IDAT chunks, inflated.
+ *
+ * A PNG may split the compressed stream across several IDAT chunks, so they
+ * are collected in order before inflating.
+ *
+ * @param {Buffer} buf
+ * @returns {Buffer | null} null if there is no IDAT or the stream is corrupt.
+ */
+function inflateIdat(buf) {
+  /** @type {Buffer[]} */
+  const chunks = [];
+  let pos = 8; // past the 8-byte signature
+  while (pos + 8 <= buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const type = buf.toString('ascii', pos + 4, pos + 8);
+    if (type === 'IEND') break;
+    if (type === 'IDAT') chunks.push(buf.subarray(pos + 8, pos + 8 + len));
+    pos += 12 + len; // length + type + data + crc
+  }
+  if (chunks.length === 0) return null;
+
+  try {
+    return inflateSync(Buffer.concat(chunks));
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Fraction of a PNG's pixels that are not near-white, or null if the file is
  * in a format this reader does not decode.
@@ -93,6 +180,8 @@ const WHITE = 240;
  * @returns {number | null}
  */
 export function inkRatio(buf) {
+  if (buf.length < IHDR_END) return null;
+
   const width = buf.readUInt32BE(16);
   const height = buf.readUInt32BE(20);
   const bitDepth = buf.readUInt8(24);
@@ -101,77 +190,23 @@ export function inkRatio(buf) {
   if (bitDepth !== 8 || colorType !== 2 || interlace !== 0) return null;
   if (!width || !height) return null;
 
-  // Concatenate the IDAT chunks — a PNG may split the stream across several.
-  /** @type {Buffer[]} */
-  const idat = [];
-  let pos = 8; // past the signature
-  while (pos + 8 <= buf.length) {
-    const len = buf.readUInt32BE(pos);
-    const type = buf.toString('ascii', pos + 4, pos + 8);
-    if (type === 'IDAT') idat.push(buf.subarray(pos + 8, pos + 8 + len));
-    else if (type === 'IEND') break;
-    pos += 12 + len; // length + type + data + crc
-  }
-  if (idat.length === 0) return null;
+  const raw = inflateIdat(buf);
+  if (raw === null) return null;
 
-  /** @type {Buffer} */
-  let raw;
-  try {
-    raw = inflateSync(Buffer.concat(idat));
-  } catch {
-    return null;
-  }
-
-  const bpp = 3; // RGB
-  const stride = width * bpp;
+  const stride = width * RGB_BPP;
+  // Each scanline is one filter byte plus `stride` bytes of pixel data.
   if (raw.length < height * (stride + 1)) return null;
 
-  // Undo the per-scanline filters. Each scanline is a filter byte followed by
-  // `stride` bytes; filters reference the pixel to the left (a), the one above
-  // (b) and the one above-left (c). Reconstructed rows are written back into
-  // `line`, which then becomes the previous row.
   const prev = Buffer.alloc(stride);
   const line = Buffer.alloc(stride);
   let ink = 0;
 
   for (let y = 0; y < height; y++) {
     const start = y * (stride + 1);
-    const filter = raw[start];
     raw.copy(line, 0, start + 1, start + 1 + stride);
+    if (!unfilterRow(raw[start], line, prev)) return null;
 
-    for (let i = 0; i < stride; i++) {
-      const a = i >= bpp ? line[i - bpp] : 0;
-      const b = prev[i];
-      const c = i >= bpp ? prev[i - bpp] : 0;
-      let add = 0;
-      switch (filter) {
-        case 0:
-          break;
-        case 1:
-          add = a;
-          break;
-        case 2:
-          add = b;
-          break;
-        case 3:
-          add = (a + b) >> 1;
-          break;
-        case 4: {
-          // Paeth: pick whichever of a, b, c the linear estimate is nearest.
-          const p = a + b - c;
-          const pa = Math.abs(p - a);
-          const pb = Math.abs(p - b);
-          const pc = Math.abs(p - c);
-          add = pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
-          break;
-        }
-        default:
-          return null; // unknown filter — do not guess
-      }
-      line[i] = (line[i] + add) & 0xff;
-    }
-
-    for (let x = 0; x < stride; x += bpp) {
+    for (let x = 0; x < stride; x += RGB_BPP) {
       if (line[x] < WHITE || line[x + 1] < WHITE || line[x + 2] < WHITE) ink++;
     }
     line.copy(prev);
@@ -206,7 +241,11 @@ export async function readShots() {
     return { shots, blank };
   }
 
-  for (const file of files.sort()) {
+  // Sorted for a stable index: readdir order is filesystem-dependent, and the
+  // first file to claim a slug wins.
+  files.sort();
+
+  for (const file of files) {
     if (!file.endsWith('.png')) continue;
     // Our own baselines are the only ones with the `--story` separator;
     // Vitest's `-chromium-linux` copies never match it.

--- a/scripts/site-shots.mjs
+++ b/scripts/site-shots.mjs
@@ -1,0 +1,257 @@
+// Component preview images for the marketing site.
+//
+// The site does not render its own component thumbnails. The visual-regression
+// suite (src/components/__tests__/screenshots.test.ts) already renders one
+// representative story per component and commits the PNG as a baseline, so the
+// site build reuses those files instead of standing up a second renderer.
+//
+// The baselines are named `<category>-<name>--<story>.png`, which is the same
+// `category-name` slug the component tiles already build for their Storybook
+// deep-link. That is what makes the join possible without a hand-maintained
+// mapping.
+//
+// Two families of files live in that directory:
+//   • `primitives-button--allvariants.png`                — written by our test
+//   • `primitives-button-allvariants-chromium-linux.png`  — Vitest's own copy
+// Only the first is read here; the second is an implementation detail of the
+// browser runner and is skipped.
+//
+// Published names drop the `--story` suffix (`/shots/primitives-button.png`)
+// so that renaming a story does not change a public URL.
+import { copyFile, mkdir, readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { inflateSync } from 'node:zlib';
+
+/** Directory holding the committed visual-regression baselines. */
+export const SHOTS_SRC = resolve(process.cwd(), 'src/components/__tests__/__screenshots__');
+
+/** Site-absolute directory the previews are published under. No trailing slash. */
+export const SHOTS_URL_BASE = '/shots';
+
+/**
+ * @typedef {object} Shot
+ * @property {string} slug   `category-name`, e.g. `primitives-button`.
+ * @property {string} file   Source file name inside SHOTS_SRC.
+ * @property {number} width  Intrinsic pixel width, for the `width` attribute.
+ * @property {number} height Intrinsic pixel height, for the `height` attribute.
+ */
+
+/**
+ * Read a PNG's intrinsic size out of its IHDR chunk.
+ *
+ * A PNG is an 8-byte signature followed by IHDR, whose width and height are
+ * the two big-endian uint32s at offsets 16 and 20. That is the whole format
+ * we need, so there is no image dependency in the site build.
+ *
+ * @param {Buffer} buf
+ * @returns {{ width: number, height: number } | null} null if not a PNG.
+ */
+export function pngSize(buf) {
+  if (buf.length < 24) return null;
+  // \x89PNG\r\n\x1a\n
+  if (buf.readUInt32BE(0) !== 0x89504e47) return null;
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  if (!width || !height) return null;
+  return { width, height };
+}
+
+/**
+ * Minimum fraction of non-white pixels for a baseline to be worth publishing.
+ *
+ * Not every committed baseline actually shows its component. Four of them are
+ * blank white rectangles and a fifth is an empty container outline, because
+ * the screenshot suite captured the story wrapper before the element had
+ * rendered anything into it:
+ *
+ *   primitives-icon 0%   typography-text 0%   typography-title 0%
+ *   primitives-badge 0.8%                     primitives-button 1.2%
+ *
+ * A blank tile is worse than no tile — it reads as "this component draws
+ * nothing". They are filtered here rather than in a hard-coded deny list so
+ * that fixing the underlying stories makes the previews appear on the next
+ * build, with no change to this file.
+ *
+ * The floor sits below every baseline that does render: the sparsest real one
+ * is composite-floatbutton at 2.5%.
+ */
+const MIN_INK = 0.015;
+
+/** Channel value at or above which a pixel counts as paper rather than ink. */
+const WHITE = 240;
+
+/**
+ * Fraction of a PNG's pixels that are not near-white, or null if the file is
+ * in a format this reader does not decode.
+ *
+ * Every committed baseline is 8-bit truecolour (colour type 2), non-interlaced
+ * — that is what the browser runner writes — so that is the only combination
+ * decoded here. Anything else returns null and is published unchecked: an
+ * unrecognised encoding is not evidence that the picture is empty.
+ *
+ * @param {Buffer} buf
+ * @returns {number | null}
+ */
+export function inkRatio(buf) {
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  const bitDepth = buf.readUInt8(24);
+  const colorType = buf.readUInt8(25);
+  const interlace = buf.readUInt8(28);
+  if (bitDepth !== 8 || colorType !== 2 || interlace !== 0) return null;
+  if (!width || !height) return null;
+
+  // Concatenate the IDAT chunks — a PNG may split the stream across several.
+  /** @type {Buffer[]} */
+  const idat = [];
+  let pos = 8; // past the signature
+  while (pos + 8 <= buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const type = buf.toString('ascii', pos + 4, pos + 8);
+    if (type === 'IDAT') idat.push(buf.subarray(pos + 8, pos + 8 + len));
+    else if (type === 'IEND') break;
+    pos += 12 + len; // length + type + data + crc
+  }
+  if (idat.length === 0) return null;
+
+  /** @type {Buffer} */
+  let raw;
+  try {
+    raw = inflateSync(Buffer.concat(idat));
+  } catch {
+    return null;
+  }
+
+  const bpp = 3; // RGB
+  const stride = width * bpp;
+  if (raw.length < height * (stride + 1)) return null;
+
+  // Undo the per-scanline filters. Each scanline is a filter byte followed by
+  // `stride` bytes; filters reference the pixel to the left (a), the one above
+  // (b) and the one above-left (c). Reconstructed rows are written back into
+  // `line`, which then becomes the previous row.
+  const prev = Buffer.alloc(stride);
+  const line = Buffer.alloc(stride);
+  let ink = 0;
+
+  for (let y = 0; y < height; y++) {
+    const start = y * (stride + 1);
+    const filter = raw[start];
+    raw.copy(line, 0, start + 1, start + 1 + stride);
+
+    for (let i = 0; i < stride; i++) {
+      const a = i >= bpp ? line[i - bpp] : 0;
+      const b = prev[i];
+      const c = i >= bpp ? prev[i - bpp] : 0;
+      let add = 0;
+      switch (filter) {
+        case 0:
+          break;
+        case 1:
+          add = a;
+          break;
+        case 2:
+          add = b;
+          break;
+        case 3:
+          add = (a + b) >> 1;
+          break;
+        case 4: {
+          // Paeth: pick whichever of a, b, c the linear estimate is nearest.
+          const p = a + b - c;
+          const pa = Math.abs(p - a);
+          const pb = Math.abs(p - b);
+          const pc = Math.abs(p - c);
+          add = pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+          break;
+        }
+        default:
+          return null; // unknown filter — do not guess
+      }
+      line[i] = (line[i] + add) & 0xff;
+    }
+
+    for (let x = 0; x < stride; x += bpp) {
+      if (line[x] < WHITE || line[x + 1] < WHITE || line[x + 2] < WHITE) ink++;
+    }
+    line.copy(prev);
+  }
+
+  return ink / (width * height);
+}
+
+/**
+ * Index every usable baseline by its `category-name` slug.
+ *
+ * Baselines that render (almost) nothing are reported separately instead of
+ * being published — see MIN_INK.
+ *
+ * Never throws: a missing or unreadable directory yields an empty index, and
+ * the site falls back to text-only tiles. A landing page must still build on a
+ * checkout where the baselines were never generated.
+ *
+ * @returns {Promise<{ shots: Record<string, Shot>, blank: string[] }>}
+ */
+export async function readShots() {
+  /** @type {Record<string, Shot>} */
+  const shots = {};
+  /** @type {string[]} */
+  const blank = [];
+
+  /** @type {string[]} */
+  let files;
+  try {
+    files = await readdir(SHOTS_SRC);
+  } catch {
+    return { shots, blank };
+  }
+
+  for (const file of files.sort()) {
+    if (!file.endsWith('.png')) continue;
+    // Our own baselines are the only ones with the `--story` separator;
+    // Vitest's `-chromium-linux` copies never match it.
+    const slug = file.split('--')[0];
+    if (!slug || slug === file) continue;
+    if (shots[slug]) continue;
+
+    /** @type {Buffer} */
+    let buf;
+    try {
+      buf = await readFile(join(SHOTS_SRC, file));
+    } catch {
+      continue;
+    }
+
+    const size = pngSize(buf);
+    if (!size) continue;
+
+    const ink = inkRatio(buf);
+    if (ink !== null && ink < MIN_INK) {
+      blank.push(slug);
+      continue;
+    }
+
+    shots[slug] = { slug, file, width: size.width, height: size.height };
+  }
+
+  return { shots, blank };
+}
+
+/**
+ * Copy an index's PNGs into `<outDir>/shots/`, renamed to their slug.
+ *
+ * @param {Record<string, Shot>} shots
+ * @param {string} outDir Build output directory (dist-site).
+ * @returns {Promise<number>} How many files were written.
+ */
+export async function copyShots(shots, outDir) {
+  const entries = Object.values(shots);
+  if (entries.length === 0) return 0;
+
+  const dest = join(outDir, 'shots');
+  await mkdir(dest, { recursive: true });
+  await Promise.all(
+    entries.map((s) => copyFile(join(SHOTS_SRC, s.file), join(dest, `${s.slug}.png`))),
+  );
+  return entries.length;
+}

--- a/scripts/site-shots.mjs
+++ b/scripts/site-shots.mjs
@@ -216,6 +216,25 @@ export function inkRatio(buf) {
 }
 
 /**
+ * Compare two file names by UTF-16 code unit.
+ *
+ * Explicit rather than a bare `sort()`, and deliberately not
+ * `String#localeCompare`: this orders build inputs, so it has to give the same
+ * answer on every machine. Locale collation treats `-` as a variable character
+ * and can order `foo-bar` and `foobar` differently between runners, which is
+ * exactly the instability the sort exists to remove.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function byCodeUnit(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
  * Index every usable baseline by its `category-name` slug.
  *
  * Baselines that render (almost) nothing are reported separately instead of
@@ -243,7 +262,7 @@ export async function readShots() {
 
   // Sorted for a stable index: readdir order is filesystem-dependent, and the
   // first file to claim a slug wins.
-  files.sort();
+  files.sort(byCodeUnit);
 
   for (const file of files) {
     if (!file.endsWith('.png')) continue;

--- a/src/site/content.ts
+++ b/src/site/content.ts
@@ -34,6 +34,7 @@ import {
   type ComponentEntry,
 } from './data';
 import { PACKAGE_NAME, REPO_URL, ROUTES, type Route } from './routes';
+import { shotAlt, shotKey, shotUrl, type ShotIndex } from './shots';
 
 export interface ContentOptions {
   /** Deployed Storybook base URL — resolved by the build, not by data.ts. */
@@ -42,6 +43,8 @@ export interface ContentOptions {
   stars: string;
   /** Package version for the colophon. */
   version: string;
+  /** Component preview images, keyed by `category-name`. May be empty. */
+  shots: ShotIndex;
 }
 
 /** Storybook docs deep-link. Mirrors Storybook's slug rule. */
@@ -140,6 +143,35 @@ function featuresMain(route: Route): string {
 /* --------------------------------------------------------------------- *
  * Page 3 — Components overview
  * --------------------------------------------------------------------- */
+
+/**
+ * Preview image for one tile.
+ *
+ * A real `<img>` rather than a CSS background: the picture is the tile's
+ * content, so it needs alt text, and a background image is invisible to both
+ * screen readers and image search.
+ *
+ * `width`/`height` carry the PNG's intrinsic size so the aspect ratio is known
+ * before the bytes arrive; the CSS then fits the image inside a fixed-height
+ * frame, which is what actually pins the grid against layout shift.
+ *
+ * Four components have no baseline yet (Layout, Affix, Anchor, BackTop — none
+ * has a story the screenshot suite renders). They get a decorative placeholder
+ * so the grid keeps its rhythm; the tile's name and tag are already text, so
+ * nothing is lost by hiding it from assistive tech.
+ */
+function tileShot(entry: ComponentEntry, shots: ShotIndex): string {
+  const shot = shots[shotKey(entry)];
+  if (!shot) {
+    return `<span class="site-comp__shot site-comp__shot--none" aria-hidden="true"></span>`;
+  }
+  return `<span class="site-comp__shot"
+              ><img src="${esc(shotUrl(shot))}" alt="${esc(shotAlt(entry))}"
+                    width="${shot.width}" height="${shot.height}"
+                    loading="lazy" decoding="async"
+              /></span>`;
+}
+
 function componentsMain(route: Route, opts: ContentOptions): string {
   const tiles = COMPONENTS.map(
     (c) => `
@@ -147,6 +179,7 @@ function componentsMain(route: Route, opts: ContentOptions): string {
              target="_blank" rel="noopener"
              data-name="${esc(c.name.toLowerCase())}"
              data-tag="${esc(c.tag)}" data-cat="${esc(c.category)}">
+            ${tileShot(c, opts.shots)}
             <span class="site-comp__tile-name">${esc(c.name)}</span>
             <span class="site-comp__tile-tag">&lt;${esc(c.tag)}&gt;</span>
           </a>`,
@@ -161,7 +194,8 @@ function componentsMain(route: Route, opts: ContentOptions): string {
           Every component is a standalone custom element. Import the barrel to register all
           ${esc(String(COMPONENTS.length))}, or import a single module — <code>${esc(
             PACKAGE_NAME,
-          )}/button</code> — and ship only that. Each tile links to its Storybook documentation.
+          )}/button</code> — and ship only that. Each tile previews the component as it renders on
+          an e-paper page and links to its Storybook documentation.
         </p>
 
         <!-- Search and category filter are progressive enhancement: the full

--- a/src/site/seo.ts
+++ b/src/site/seo.ts
@@ -19,6 +19,7 @@ import {
   type Route,
 } from './routes';
 import { COMPONENTS, FEATURES } from './data';
+import { shotAlt, shotKey, shotUrl, type ShotIndex } from './shots';
 
 const AUTHOR = { '@type': 'Person', name: 'Marco Mattes', url: 'https://mattes.dev' } as const;
 
@@ -77,8 +78,36 @@ function breadcrumb(route: Route): Record<string, unknown> {
   };
 }
 
+/**
+ * `ImageObject` for a component's preview, or undefined when it has none.
+ *
+ * The picture is already on the page with alt text; this restates it in a form
+ * an image crawler can resolve without parsing the markup, and gives the
+ * caption an engine quotes when it surfaces the thumbnail.
+ */
+function shotImage(
+  entry: (typeof COMPONENTS)[number],
+  shots: ShotIndex,
+): Record<string, unknown> | undefined {
+  const shot = shots[shotKey(entry)];
+  if (!shot) return undefined;
+  return {
+    '@type': 'ImageObject',
+    contentUrl: `${SITE_ORIGIN}${shotUrl(shot)}`,
+    width: shot.width,
+    height: shot.height,
+    caption: shotAlt(entry),
+    encodingFormat: 'image/png',
+    license: 'https://spdx.org/licenses/MIT.html',
+  };
+}
+
 /** Route-specific structured data — the part an answer engine can cite. */
-function routeGraph(route: Route, storybookBase: string): Record<string, unknown>[] {
+function routeGraph(
+  route: Route,
+  storybookBase: string,
+  shots: ShotIndex,
+): Record<string, unknown>[] {
   switch (route.dir) {
     case 'features':
       return [
@@ -105,6 +134,7 @@ function routeGraph(route: Route, storybookBase: string): Record<string, unknown
             name: c.name,
             description: `<${c.tag}> — ${c.category} component, importable as ${PACKAGE_NAME}/${c.tag.replace(/^e-/, '')}`,
             url: `${storybookBase}/?path=/docs/${`${c.category}-${c.name}`.toLowerCase().replace(/[^a-z0-9-]+/g, '-')}--docs`,
+            image: shotImage(c, shots),
           })),
         },
       ];
@@ -146,7 +176,10 @@ function routeGraph(route: Route, storybookBase: string): Record<string, unknown
  * The full <head> block for a route: title, description, canonical, Open
  * Graph, Twitter card and JSON-LD.
  */
-export function headHtml(route: Route, opts: { version: string; storybookBase: string }): string {
+export function headHtml(
+  route: Route,
+  opts: { version: string; storybookBase: string; shots: ShotIndex },
+): string {
   const url = absoluteUrl(route.path);
   const graph: Record<string, unknown>[] = [
     {
@@ -169,7 +202,7 @@ export function headHtml(route: Route, opts: { version: string; storybookBase: s
     },
     softwareGraph(opts.version),
     breadcrumb(route),
-    ...routeGraph(route, opts.storybookBase),
+    ...routeGraph(route, opts.storybookBase, opts.shots),
   ];
 
   return `<title>${esc(route.title)}</title>

--- a/src/site/shots.ts
+++ b/src/site/shots.ts
@@ -1,0 +1,52 @@
+// Types and URL rules for the component preview images.
+//
+// The images themselves are indexed and copied by scripts/site-shots.mjs,
+// which needs `node:fs`. This module is the browser-safe half: the shape of
+// that index, plus the two pure functions that turn a component entry into a
+// lookup key and a public URL. Both content.ts (markup) and seo.ts (structured
+// data) go through here, so the slug rule is stated once.
+import type { ComponentEntry } from './data';
+
+/** One published preview image. Mirrors the `Shot` typedef in site-shots.mjs. */
+export interface Shot {
+  /** `category-name`, e.g. `primitives-button`. */
+  slug: string;
+  /** Source file name of the visual-regression baseline. */
+  file: string;
+  /** Intrinsic pixel width — emitted as the `width` attribute. */
+  width: number;
+  /** Intrinsic pixel height — emitted as the `height` attribute. */
+  height: number;
+}
+
+/** Preview images keyed by `category-name`. Empty when none were generated. */
+export type ShotIndex = Record<string, Shot>;
+
+/** Directory the previews are served from. No trailing slash. */
+export const SHOTS_URL_BASE = '/shots';
+
+/**
+ * Lookup key for a component: `category-name`, lowercased.
+ *
+ * Deliberately the same slug the Storybook deep-link is built from, because
+ * both derive from the story's `title`. Keep the two in step.
+ */
+export function shotKey(entry: ComponentEntry): string {
+  return `${entry.category}-${entry.name}`.toLowerCase().replace(/[^a-z0-9-]+/g, '-');
+}
+
+/** Site-absolute URL of a preview image. */
+export function shotUrl(shot: Shot): string {
+  return `${SHOTS_URL_BASE}/${shot.slug}.png`;
+}
+
+/**
+ * Alt text for a preview.
+ *
+ * Written to be useful read aloud and specific enough to stand on its own in
+ * an image search result: which component, which tag, and what the picture
+ * actually shows.
+ */
+export function shotAlt(entry: ComponentEntry): string {
+  return `EPaper ${entry.name} component — <${entry.tag}> rendered in the ink theme`;
+}

--- a/src/site/site.css
+++ b/src/site/site.css
@@ -319,7 +319,9 @@ body {
 }
 .site-comp__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  /* Wider than the old text-only tile: the previews are screenshots of real
+     components, and a button label has to stay readable at tile scale. */
+  grid-template-columns: repeat(auto-fill, minmax(212px, 1fr));
   gap: 0;
   border: var(--ink-border);
   border-right: none;
@@ -328,11 +330,12 @@ body {
 .site-comp__tile {
   border-right: var(--ink-border);
   border-bottom: var(--ink-border);
-  padding: 14px 16px;
+  /* The preview is full-bleed inside the tile, so the padding moved onto the
+     two text rows. */
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-height: 84px;
+  gap: 0;
   color: var(--ink-fg);
   text-decoration: none;
 }
@@ -343,11 +346,50 @@ body {
 .site-comp__tile[hidden] {
   display: none;
 }
+
+/* ---------- Component preview ----------
+   A fixed-height frame the image is fitted into. The baselines range from
+   296×80 (button) to 411×553 (calendar), so nothing but `contain` inside a
+   constant box keeps 59 tiles on a shared baseline grid. The fixed height is
+   also what makes the layout immune to a slow or failed image load. */
+.site-comp__shot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 128px;
+  padding: var(--ink-space-3);
+  box-sizing: border-box;
+  border-bottom: var(--ink-border);
+  overflow: hidden;
+}
+.site-comp__shot img {
+  display: block;
+  /* Overrides the intrinsic width/height attributes, which are there for the
+     aspect ratio rather than for sizing. Never upscale: these are 1-bit
+     renderings and enlarging them only softens the edges. */
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+}
+/* Components without a screenshot baseline. Decorative, no text — the tile
+   already names the component below.
+
+   A dot grid rather than diagonal hatching: <e-skeleton> renders 45° stripes,
+   so a hatched placeholder would be indistinguishable from that component's
+   own preview two rows down. Nothing in the library draws a dot grid. */
+.site-comp__shot--none {
+  background-image: radial-gradient(circle, var(--ink-fg) 1px, transparent 1px);
+  background-size: 9px 9px;
+  opacity: 0.18;
+}
+
 .site-comp__tile-name {
   font-family: var(--ink-mono);
   font-size: var(--ink-text-small);
   font-weight: 700;
   letter-spacing: 0.04em;
+  padding: 12px 14px 4px;
 }
 .site-comp__tile-tag {
   font-family: var(--ink-mono);
@@ -355,6 +397,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   opacity: 0.8;
+  padding: 0 14px 12px;
 }
 .site-comp__count {
   font-family: var(--ink-mono);
@@ -468,11 +511,17 @@ e-site-pager {
 
   /* One tile per row wastes the screen; two short ones read like an index. */
   .site-comp__grid {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(152px, 1fr));
   }
-  .site-comp__tile {
-    min-height: 62px;
-    padding: 10px 12px;
+  .site-comp__shot {
+    height: 92px;
+    padding: var(--ink-space-2);
+  }
+  .site-comp__tile-name {
+    padding: 9px 11px 3px;
+  }
+  .site-comp__tile-tag {
+    padding: 0 11px 9px;
   }
   .site-cover__hero h1 {
     /* 8vw overshoots on a phone: "components" alone is ~10 characters. */

--- a/vite.site.config.ts
+++ b/vite.site.config.ts
@@ -8,10 +8,11 @@
 // scripts/build-site-routes.mjs. Page markup comes from src/site/content.ts
 // and the <head> from src/site/seo.ts, both of which run here in Node.
 import { defineConfig, type Plugin } from 'vite';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { createReadStream, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { formatStars, resolveStars } from './scripts/github-stars.mjs';
 import { applyRouteBlocks } from './scripts/site-template.mjs';
+import { copyShots, readShots, SHOTS_SRC } from './scripts/site-shots.mjs';
 import { mainHtml, navHtml, pagenavHtml, type ContentOptions } from './src/site/content';
 import { headHtml, llmsTxt, robotsTxt, sitemapXml } from './src/site/seo';
 import { routeByPath, ROUTES, type Route } from './src/site/routes';
@@ -30,7 +31,11 @@ interface RouteBlocks {
 
 function blocksFor(route: Route, opts: ContentOptions): RouteBlocks {
   return {
-    head: `\n    ${headHtml(route, { version: opts.version, storybookBase: opts.storybookBase })}\n    `,
+    head: `\n    ${headHtml(route, {
+      version: opts.version,
+      storybookBase: opts.storybookBase,
+      shots: opts.shots,
+    })}\n    `,
     main: mainHtml(route, opts),
     nav: navHtml(route, opts.storybookBase),
     pagenav: pagenavHtml(route),
@@ -51,6 +56,23 @@ function sitePagesPlugin(opts: ContentOptions): Plugin {
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         const url = (req.url ?? '/').split('?')[0] ?? '/';
+
+        // Component previews. In a build these are copied into dist-site;
+        // in dev they are streamed straight out of the screenshot baselines
+        // so `npm run test:visual:update` shows up on the next reload.
+        const shotSlug = /^\/shots\/([a-z0-9-]+)\.png$/.exec(url)?.[1];
+        if (shotSlug) {
+          const shot = opts.shots[shotSlug];
+          if (!shot) {
+            res.statusCode = 404;
+            res.end('Not found');
+            return;
+          }
+          res.setHeader('Content-Type', 'image/png');
+          createReadStream(join(SHOTS_SRC, shot.file)).pipe(res);
+          return;
+        }
+
         const route = routeByPath(url);
         // The home page goes through Vite's own index.html handling.
         if (!route || !route.dir) return next();
@@ -78,7 +100,11 @@ function sitePagesPlugin(opts: ContentOptions): Plugin {
 
     // The five sub-pages are written after the CSS/JS inlining step, so hand
     // their content over instead of writing HTML here.
-    closeBundle() {
+    async closeBundle() {
+      const outDir = resolve(__dirname, 'dist-site');
+      const copied = await copyShots(opts.shots, outDir);
+      console.log(`[site] component previews: copied ${copied} PNG(s) to dist-site/shots/`);
+
       const lastmod = new Date().toISOString().slice(0, 10);
       const manifest = {
         routes: ROUTES.map((r) => ({ path: r.path, dir: r.dir, blocks: blocksFor(r, opts) })),
@@ -88,11 +114,7 @@ function sitePagesPlugin(opts: ContentOptions): Plugin {
           'llms.txt': llmsTxt({ version: opts.version, stars: opts.stars }),
         },
       };
-      writeFileSync(
-        resolve(__dirname, 'dist-site/_site-routes.json'),
-        JSON.stringify(manifest),
-        'utf8',
-      );
+      writeFileSync(join(outDir, '_site-routes.json'), JSON.stringify(manifest), 'utf8');
     },
   };
 }
@@ -111,10 +133,33 @@ export default defineConfig(async () => {
     console.log(`[site] GitHub stars: ${starsText} (${stars.count}, source: ${stars.source})`);
   }
 
+  // Component tile previews, reused from the visual-regression baselines.
+  // Never fatal either: an empty index just means text-only tiles.
+  const { shots, blank } = await readShots();
+  const shotCount = Object.keys(shots).length;
+  if (shotCount === 0) {
+    console.warn(
+      '[site] component previews: no screenshot baselines found — tiles render without images. ' +
+        'Run `npm run test:visual` to generate them.',
+    );
+  } else {
+    console.log(`[site] component previews: ${shotCount} baseline(s) indexed`);
+  }
+  if (blank.length > 0) {
+    // Surfaced on every build rather than swallowed: a blank baseline means
+    // the screenshot suite is asserting against an empty picture, so the
+    // visual regression it exists to catch would pass silently.
+    console.warn(
+      `[site] component previews: skipped ${blank.length} blank baseline(s) — ${blank.join(', ')}. ` +
+        'These stories render nothing under the screenshot harness; their tiles stay text-only.',
+    );
+  }
+
   const content: ContentOptions = {
     storybookBase: process.env['VITE_STORYBOOK_BASE'] || 'http://localhost:6006',
     stars: starsText,
     version: pkg.version,
+    shots,
   };
 
   return {

--- a/vite.site.config.ts
+++ b/vite.site.config.ts
@@ -69,7 +69,9 @@ function sitePagesPlugin(opts: ContentOptions): Plugin {
             return;
           }
           res.setHeader('Content-Type', 'image/png');
-          createReadStream(join(SHOTS_SRC, shot.file)).pipe(res);
+          // An unhandled 'error' here (baseline deleted mid-session) would
+          // take the dev server down with it.
+          createReadStream(join(SHOTS_SRC, shot.file)).on('error', next).pipe(res);
           return;
         }
 


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched) — site build only, no library code
- [x] Demo/story/docs updated if needed — the page 3 lede now mentions the previews
- [x] CSS output builds locally (`npm run build:site`)

Page 3 was 59 text-only tiles. Each tile now carries a picture of the component it names, taken from the visual-regression baselines the screenshot suite already commits — no second renderer and no new image assets.

**How the join works.** The baselines are named `<category>-<name>--<story>.png`, which is the same `category-name` slug the tiles already build for their Storybook deep-link. `scripts/site-shots.mjs` indexes them, reads each PNG's intrinsic size out of its IHDR chunk, and copies them to `dist-site/shots/` under the slug alone, so renaming a story cannot change a public URL. In dev they are streamed from the source directory instead, so `npm run test:visual:update` shows up on the next reload.

**Markup, not decoration.** Real `<img>` elements rather than CSS backgrounds: the preview is the tile's content, so it needs alt text, and a background image is invisible to both screen readers and image search. Each is lazy-loaded and carries its intrinsic `width`/`height`; a fixed-height frame — not the attributes — is what makes the grid immune to a slow or failed load. The page also restates each preview as an `ImageObject` inside its existing `ItemList`, so an image crawler can resolve the file without parsing markup.

**Five baselines are not pictures of anything.** `primitives-icon`, `typography-text` and `typography-title` are blank white; `primitives-badge` is 0.8% ink; `primitives-button` is an empty container outline. The screenshot harness captured the story wrapper before the element rendered into it — which also means the visual regressions those five exist to catch would pass silently. Worth a separate look; this PR only stops the site from shipping them.

A blank tile reads as "this component draws nothing", so the index measures ink coverage and skips anything under 1.5%. The sparsest baseline that does render its component is `composite-floatbutton` at 2.5%, so the floor has room. The check is a real PNG decode (zlib inflate plus scanline unfiltering, no dependency) because file size does not separate blank from sparse — `floatbutton` has the lowest bytes-per-pixel of all 55. Measuring rather than deny-listing means fixing those stories makes the previews appear with no change to this code, and the build names the skipped slugs on every run so the gap stays visible:

```
[site] component previews: 50 baseline(s) indexed
[site] component previews: skipped 5 blank baseline(s) — primitives-badge, primitives-button,
       primitives-icon, typography-text, typography-title.
[site] component previews: copied 50 PNG(s) to dist-site/shots/
```

Layout, Affix, Anchor and BackTop have no baseline at all (no story the suite renders) and get a dot-grid placeholder.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm run build:site`
- [x] Rendered `dist-site/components/` in Chromium at 1280px and 390px: 50 previews load, none broken, no failed requests, no horizontal overflow
- [x] PNG ink decoder cross-checked against canvas `getImageData` on 15 baselines — max deviation 0.03 percentage points
- [ ] `npm run test:ci` — **not run.** The suite is Vitest browser mode and this container has only `chromium`, not Playwright's `chrome-headless-shell`, so it cannot launch here. No library code is touched by this change.

## Notes

- **E-Ink:** no transitions, animations or `:hover` added. The previews are the library's own 1-bit renderings and are never upscaled — `max-width`/`max-height` only — so edges stay hard.
- **Accessibility:** each preview has a unique, specific alt text (`EPaper Button component — <e-button> rendered in the ink theme`). Placeholders are `aria-hidden` and empty, since the tile already names the component in text below.
- **Placeholder pattern:** dots, not diagonal hatching. `<e-skeleton>` renders 45° stripes, and a hatched placeholder was indistinguishable from that component's own preview two rows down.
- **Payload:** 50 PNGs, ~200 KB total, all lazy-loaded and outside the inlined critical CSS/JS path.
- The 4 tiles without previews and the 5 skipped baselines are both cheap to close out later — the first needs stories, the second needs the harness to wait for the element to render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuDGQ7jMHBiYNcrnjDxJnt)_