### PR TITLE
ci: stage pipeline and retry BrowserStack

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,10 +1,14 @@
 name: BrowserStack
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # CI calls this after its local quality, test and build stages. Keeping a
+  # manual trigger is useful for diagnosing BrowserStack without rerunning CI.
+  workflow_call:
+    secrets:
+      BROWSERSTACK_USERNAME:
+        required: false
+      BROWSERSTACK_ACCESS_KEY:
+        required: false
   workflow_dispatch: {}
 
 concurrency:
@@ -93,8 +97,21 @@ jobs:
           local-testing: start
           local-identifier: random
 
-      - name: Test every component story
-        run: npm run test:browserstack -- --platform=${{ matrix.platform }}
+      - name: Test every component story (one retry)
+        shell: bash
+        run: |
+          for attempt in 1 2; do
+            if npm run test:browserstack -- --platform=${{ matrix.platform }}; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 1 ]; then
+              echo "::warning::BrowserStack failed on the first attempt; retrying once."
+            fi
+          done
+
+          echo "::error::BrowserStack failed again on the retry."
+          exit 1
 
       - name: Stop BrowserStack Local
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       # Coverage instead of a bare run: this is the only place the browser
       # suite executes, so it is also the only place coverage can be measured.
@@ -123,7 +123,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,20 +13,25 @@ on:
       # than failing, so a fork PR and a token-less clone still get a green CI.
       SONAR_TOKEN:
         required: false
+      # Optional for the same reason: BrowserStack reports a notice and skips
+      # its matrix when the credentials are unavailable.
+      BROWSERSTACK_USERNAME:
+        required: false
+      BROWSERSTACK_ACCESS_KEY:
+        required: false
 
 # Scoped per job rather than here, matching browserstack.yml: a workflow-level
 # grant hands the token to every job whether it needs one or not, and a job
 # added later inherits it silently instead of having to ask.
 jobs:
-  build:
-    name: Build and test
+  # Each stage is an explicit job so GitHub shows the gate that failed and
+  # never schedules the more expensive stages behind it.
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
     container:
-      # Keep the browser, its system dependencies, and visual-regression
-      # rendering identical to the environment used to create CI baselines.
-      # This tag must match the Playwright version in package-lock.json.
       image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --user 1001
     steps:
@@ -51,6 +56,30 @@ jobs:
       - name: Type check
         run: npm run type-check
 
+  tests:
+    name: Tests
+    needs: quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      # Keep browser rendering identical to the environment used to create the
+      # visual-regression baselines. This tag must match package-lock.json.
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       # Coverage instead of a bare run: this is the only place the browser
       # suite executes, so it is also the only place coverage can be measured.
       # Both Vitest projects (`unit` and `storybook`) report into it, and V8
@@ -69,6 +98,32 @@ jobs:
           path: reports/
           retention-days: 14
           if-no-files-found: warn
+
+  build:
+    # Keep the current check name stable for branch protection.
+    name: Build and test
+    needs: tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      # Keep the browser, its system dependencies, and visual-regression
+      # rendering identical to the environment used to create CI baselines.
+      # This tag must match the Playwright version in package-lock.json.
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         run: npm run build
@@ -101,7 +156,7 @@ jobs:
           fetch-depth: 0
 
       # Analysis runs outside the Playwright container and never re-runs the
-      # suite; it only needs the reports the build job already produced.
+      # suite; it only needs the reports the tests job already produced.
       - name: Download test and coverage reports
         uses: actions/download-artifact@v4
         with:
@@ -155,3 +210,38 @@ jobs:
           # later. Everything else comes from sonar-project.properties.
           args: >
             -Dsonar.qualitygate.wait=true
+
+  browserstack:
+    name: BrowserStack
+    needs: sonar
+    permissions:
+      contents: read
+    uses: ./.github/workflows/browserstack.yml
+    secrets:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+  # Delivery is part of the same gated chain. A pull request gets its preview;
+  # main gets the production site. Tag releases deploy from release.yml after
+  # publishing, so they deliberately match neither condition here.
+  preview:
+    name: PR preview
+    needs: browserstack
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/preview.yml
+    secrets: inherit
+
+  deploy:
+    name: Deploy site and Storybook
+    needs: browserstack
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,11 +20,9 @@ name: Deploy to FTP
 #   FTP_PORT       default 21
 
 on:
-  push:
-    branches: [main]
+  # Main-branch deploys are called by ci.yml after every preceding gate passed;
+  # tagged releases call this after publishing from release.yml.
   workflow_dispatch: {}
-  # Called as the update stage of release.yml. The checkout then resolves to
-  # the caller's ref, so a release deploys the tagged source, not main's head.
   workflow_call: {}
 
 permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,8 +21,11 @@ name: PR Preview
 #   FTP_SERVER_DIR (optional, default "/"), FTP_PROTOCOL, FTP_PORT
 
 on:
+  # Preview creation is called by ci.yml only after all checks passed. Closing
+  # remains a direct trigger because cleanup must not depend on CI.
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,20 @@ jobs:
   checks:
     name: Checks
     needs: guard
+    # Nested workflows may only retain or reduce the caller's permissions.
+    # ci.yml uses this permission only in its PR-preview job, which is skipped
+    # for a tag release; declaring it here keeps the reusable graph valid.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     # Passed explicitly rather than via `secrets: inherit`, so the reusable
-    # workflow never sees NPM_TOKEN or the FTP credentials. Unset in a fork,
-    # where ci.yml then skips the analysis instead of failing.
+    # workflow never sees NPM_TOKEN or the FTP credentials. Missing optional
+    # credentials make their corresponding remote check skip with a notice.
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
   # ---------------------------------------------------- stage 3 · release
   release:

--- a/BROWSERSTACK.md
+++ b/BROWSERSTACK.md
@@ -59,16 +59,18 @@ Create these repository Actions secrets:
 - `BROWSERSTACK_USERNAME`
 - `BROWSERSTACK_ACCESS_KEY`
 
-`.github/workflows/browserstack.yml` runs for every pull request and every push
-to `main`. Fork pull requests do not receive repository secrets, so the workflow
+`.github/workflows/ci.yml` calls `.github/workflows/browserstack.yml` after the
+local quality, test, and build stages for every pull request and every push to
+`main`. Fork pull requests do not receive repository secrets, so the workflow
 reports a notice and skips the remote matrix for those runs. It never uses
 `pull_request_target` and therefore never exposes BrowserStack credentials to
 untrusted fork code.
 
 Each matrix job builds a static Storybook, starts an isolated BrowserStack Local
-tunnel, runs all stories in one remote session, stops the tunnel even on failure,
-and uploads the reports for 14 days. The official BrowserStack Actions are pinned
-to an immutable commit.
+tunnel, runs all stories in one remote session, and retries that complete remote
+test once if it fails. Setup and build failures are not retried. The job stops
+the tunnel even on failure and uploads the reports for 14 days. The official
+BrowserStack Actions are pinned to an immutable commit.
 
 ## Run locally
 

--- a/README.md
+++ b/README.md
@@ -791,8 +791,8 @@ stages, each gating the next:
    Storybook from the tagged source.
 
 Tags carrying a prerelease part, such as `v1.1.0-rc.1`, are published under the
-`next` dist-tag instead of `latest`. The site is additionally redeployed on every
-push to `main` by `.github/workflows/deploy.yml`.
+`next` dist-tag instead of `latest`. The site is additionally redeployed after
+the complete staged CI has passed on every push to `main`.
 
 `main` requires a pull request, so the version bump is merged before the tag is
 pushed; [CONTRIBUTING.md](./CONTRIBUTING.md) documents the exact sequence.


### PR DESCRIPTION
## Summary

- split CI into explicit `Quality → Tests → Build → SonarQube → BrowserStack` stages
- gate PR previews and main deployments on the complete successful check chain
- retry each BrowserStack platform test exactly once while keeping setup and build failures fail-fast
- preserve the existing SonarQube coverage flow and pass only the required secrets through reusable workflows
- keep PR teardown independent so closed pull requests are always cleaned up

## Why

The workflows previously started independently, so previews and deployments could run before earlier checks completed. BrowserStack also had no workflow-level retry for transient remote failures. The new dependency chain makes each stage block all downstream work while allowing one controlled BrowserStack retry.

## Impact

Pull requests and main-branch pushes now show a clear staged pipeline. A failure prevents later stages from starting. Fork pull requests continue to skip remote checks when credentials are unavailable, and tag releases reuse the same checks before publishing.

## Validation

- YAML parsing for all changed workflows
- static workflow DAG and retry assertions
- `npm run format:check`
- `npm run lint:check`
- `npm run type-check`
- `npm run build`
- `npm run size`
- `npm run validate:sample-app:types`

Local browser-backed Vitest and sample runtime validation could not complete because the matching Playwright Chromium binary is not installed locally; CI uses the pinned Playwright container.