### PR TITLE
Add form validation, panel themes, and refresh budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- High-contrast monochrome and Kaleido panel themes, shipped as readable and
+  minified CSS subpath exports. Semantic accent/status tokens collapse to black
+  in the base theme and map to flat Kaleido colors without removing icon,
+  border-weight or hatch cues.
+- An automated e-paper refresh-budget suite for representative progress,
+  time-picker, table, select and tabs interactions. It fails on host-subtree
+  replacement and enforces per-scenario mutation, element-churn and
+  approximated dirty-area limits.
 - SonarQube Cloud analysis on every pull request and every push to `main`.
   `sonar-project.properties` carries the configuration; the `sonar` job in
   `ci.yml` consumes the coverage and test reports the test job produced rather
@@ -87,6 +95,14 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- All thirteen `BaseFormControl` subclasses now participate in native
+  constraint validation. Composite controls implement a shared `required`
+  contract through `ElementInternals`; text and number controls mirror their
+  inner native control's validity flags and use its focusable validation
+  anchor.
+- The public roadmap is outcome-based: V1.1 groups form reliability, panel
+  themes and refresh budgets, while hardware adapters and SSR helpers remain
+  demand-driven rather than carrying premature version promises.
 - The coverage thresholds are now a regression floor rather than a target. CI
   previously ran without `--coverage`, so the branch threshold of 70% was never
   evaluated against the 65.5% the suite actually reaches; it is now 65%, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,11 @@ sample-app/           Validates README.md's runtime + TS claims against dist/. N
    `patchBoolAttr` / `patchClassModifier`. Do not replace subtrees with
    `innerHTML` reassignment after the initial render — it forces a full
    GC16 EPDC waveform.
-8. **JSDoc is required** with `@summary`, `@attr`, `@fires`, `@slot`,
-   `@example`. The Custom Elements Manifest analyzer reads it; without
-   JSDoc there is no IDE autocomplete.
+8. **JSDoc is required** with `@summary`, `@since`, `@attr`, `@fires`,
+   `@slot`, `@example`. The Custom Elements Manifest analyzer reads it;
+   without JSDoc there is no IDE autocomplete. Use the first public release
+   version, e.g. `@since v1.0.1` or `@since v1.1.0`, and check the git tag
+   history before claiming a newer version.
 9. **TypeScript is strict.** No `any` outside escape hatches. The CI gate
    is `npm run lint:check` (`--max-warnings=0`). Don't add ESLint disables
    without a comment.
@@ -80,6 +82,7 @@ import { define, esc } from '../core/dom';
 
 /**
  * @summary Short description.
+ * @since v1.0.1
  * @attr {string} [foo] - Description.
  * @fires {CustomEvent<{value: string}>} e-change - Description.
  * @slot - Default slot description.
@@ -134,6 +137,7 @@ npm run dev          # Vite demo at localhost:8085
 npm run storybook    # Storybook at localhost:6006
 npm test             # Vitest watch (browser mode, Playwright)
 npm run test:ci      # Vitest run-once (CI)
+npm run test:refresh # Mutation / node-churn / dirty-area budgets
 npm run test:coverage:ci  # Vitest run-once + coverage + Sonar reports
 npm run type-check   # tsc --noEmit, must be clean
 npm run lint:check   # ESLint, max-warnings=0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,14 @@ component or under `src/components/__tests__/` covering at minimum:
 - Event emission with the documented detail shape.
 - For form controls: `FormData` round-trip from a `<form>` parent.
 - For interactive components: keyboard activation paths.
+- For a frequently updated component: add or update a scenario in
+  `refresh-budget.test.ts`. Value-only interactions must not replace the host
+  subtree; keep mutation count, element churn and approximated dirty area under
+  an explicit per-scenario budget.
+
+Run only the refresh scenarios with `npm run test:refresh`. The dirty-area
+metric is a browser-side approximation based on mutated elements' bounding
+rectangles; physical ghosting and waveform choice still require panel testing.
 
 ## Coverage and SonarQube
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -161,12 +161,11 @@ Form controls behave like native ones:
 - `formResetCallback` (Reset button) → re-applies `default-value`.
 - `formStateRestoreCallback` → BFCache and autofill restore.
 
-> **Validation note (V1.0).** `<e-input>` and `<e-textarea>` set
-> `aria-invalid="true"` via the `error` attribute but do not call
-> `internals.setValidity()`. `<e-upload>` does. If you rely on
-> `form.checkValidity()`, attach native HTML attributes (`required`,
-> `pattern`, `minlength`) alongside `error` on V1.0. A unified
-> validation API is on the V1.1 roadmap.
+> **Validation note.** All thirteen `BaseFormControl` subclasses participate in
+> constraint validation through `ElementInternals`. Text and number controls
+> mirror the validity flags of their native inner control; selection, boolean
+> and file controls report `valueMissing` from their component-level
+> `required` attribute.
 
 ---
 
@@ -208,15 +207,17 @@ your own components.
 | Test suite                           | Verifies                                       | Coverage          |
 | ------------------------------------ | ---------------------------------------------- | ----------------- |
 | `__tests__/cleanup.test.ts`          | `onGlobal` / `runCleanups` memory-leak pattern | 9 components      |
-| `__tests__/form-association.test.ts` | `FormData` round-trip, reset callback          | 14 form controls  |
+| `__tests__/form-association.test.ts` | `FormData`, reset/restore, constraint validity | 14 form controls  |
 | `__tests__/reactivity.test.ts`       | `attributeChangedCallback` updates             | 7 components      |
 | `__tests__/security.test.ts`         | XSS injection through `esc()` paths            | 12 components     |
+| `__tests__/screenshots.test.ts`      | Pixel visual regression                        | all story modules |
+| `__tests__/refresh-budget.test.ts`   | Mutation, node-churn and dirty-area budgets    | key interactions  |
 | `core/date.test.ts`                  | `parseYMD`, `ymd`, `pad2`                      | core utility      |
 | Storybook + `@storybook/addon-a11y`  | axe-core (WCAG 2A + 2AA + best practice)       | all 64 components |
 
-**Intentionally out of scope for V1.0:** visual regression, keyboard
-navigation, touch interaction. These run manually before each release
-through Storybook stories.
+Visual regression, keyboard navigation and refresh budgets run in CI. Physical
+panel ghosting and waveform selection remain hardware checks because browser
+DOM APIs cannot observe the EPDC's final refresh decision.
 
 ---
 
@@ -232,6 +233,7 @@ through Storybook stories.
 | VS Code Custom Data                  | `dist/vscode.html-custom-data.json`            | HTML autocomplete                             |
 | WebStorm/IntelliJ Web-Types          | `dist/web-types.json`                          | JetBrains autocomplete                        |
 | CSS layers                           | `dist/styles/{tokens,base,components}.min.css` | Includes `.map` files                         |
+| Panel themes                         | `dist/styles/themes/*.min.css`                 | Optional mono-high-contrast / Kaleido packs   |
 | Combined CSS bundle                  | `dist/styles/epaper.min.css`                   | Single-file drop-in                           |
 
 `npm pack --dry-run` shows what is actually published — recommended
@@ -245,34 +247,18 @@ before any release. The `files` whitelist in `package.json` ships only
 These are intentional V1.0 trade-offs. They are tracked in
 `CHANGELOG.md` under "Known limitations" and slated for V1.1.
 
-1. **Validation API split.** `<e-input>` and `<e-textarea>` set
-   `aria-invalid="true"` from the `error` attribute but do not call
-   `internals.setValidity()`, so `form.checkValidity()` ignores them.
-   `<e-upload>` uses the validation API correctly. Workaround: combine
-   `error` with native HTML attributes for form-level validation.
-2. **Keyboard navigation.** `dropdown`, `select`, `menu`, `date-picker`,
-   `time-picker`, `cascader` and `tree-select` support full keyboard
-   traversal (arrow keys, `Home`/`End`, `PageUp`/`PageDown` for
-   `date-picker`, `Enter`/`Space` to activate, `Escape` to close).
-   Implemented in V1.0.
-3. **`<e-cascader>` `options` vs `<e-tree-select>` `data`.** Same
-   mechanism (JSON in an attribute), different attribute names.
-   Parse errors are silent (empty array instead of an error event).
-4. **`<e-masonry>` does not observe child mutations or container
-   resizes.** Pages embedding it must trigger reflow manually after
-   dynamic child changes.
-5. **`<e-kaleido>`** is a hardware-fingerprint visualisation tool
+1. **`<e-kaleido>`** is a hardware-fingerprint visualisation tool
    kept in the public API for demo purposes; it is not a
    general-purpose layout primitive.
-6. **`tsconfig` is missing `noUncheckedIndexedAccess`.** Enabling it
+2. **`tsconfig` is missing `noUncheckedIndexedAccess`.** Enabling it
    surfaces ~90 latent index-access cases in pickers, calendar and
    stories. They are runtime-safe by construction but deserve precise
    typing rather than blanket non-null assertions. Tracked for V1.1.
-7. **Test coverage is thematic, not per-component.** Cross-cutting
+3. **Test coverage is thematic, not per-component.** Cross-cutting
    suites cover form-association (14 controls), reactivity (7
    components), cleanup (9 components) and security (12 components).
-   Display-only components rely on the Storybook a11y addon (axe-core)
-   for regression coverage.
+   Display-only components rely on the Storybook a11y addon (axe-core),
+   visual baselines and the refresh-budget suite for regression coverage.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -329,15 +329,17 @@ import '@marcomattes/epaper-components';
 
 Two distributions of the same three layers ship in the package:
 
-| Subpath                                             | Resolves to                      | When to use                         |
-| --------------------------------------------------- | -------------------------------- | ----------------------------------- |
-| `@marcomattes/epaper-components/tokens.css`         | `src/styles/tokens.css` (source) | Bundlers (Vite, Rollup, webpack 5). |
-| `@marcomattes/epaper-components/base.css`           | `src/styles/base.css` (source)   | Bundlers.                           |
-| `@marcomattes/epaper-components/components.css`     | `src/styles/components.css`      | Bundlers.                           |
-| `@marcomattes/epaper-components/styles.min.css`     | `dist/styles/epaper.min.css`     | Combined, minified bundle.          |
-| `@marcomattes/epaper-components/tokens.min.css`     | `dist/styles/tokens.min.css`     | Standalone minified token layer.    |
-| `@marcomattes/epaper-components/base.min.css`       | `dist/styles/base.min.css`       | Standalone minified reset.          |
-| `@marcomattes/epaper-components/components.min.css` | `dist/styles/components.min.css` | Standalone minified component CSS.  |
+| Subpath                                                        | Resolves to                                | When to use                              |
+| -------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------- |
+| `@marcomattes/epaper-components/tokens.css`                    | `src/styles/tokens.css` (source)           | Bundlers (Vite, Rollup, webpack 5).      |
+| `@marcomattes/epaper-components/base.css`                      | `src/styles/base.css` (source)             | Bundlers.                                |
+| `@marcomattes/epaper-components/components.css`                | `src/styles/components.css`                | Bundlers.                                |
+| `@marcomattes/epaper-components/themes/mono-high-contrast.css` | `src/styles/themes/mono-high-contrast.css` | Optional high-contrast monochrome theme. |
+| `@marcomattes/epaper-components/themes/kaleido.css`            | `src/styles/themes/kaleido.css`            | Optional Kaleido panel theme.            |
+| `@marcomattes/epaper-components/styles.min.css`                | `dist/styles/epaper.min.css`               | Combined, minified bundle.               |
+| `@marcomattes/epaper-components/tokens.min.css`                | `dist/styles/tokens.min.css`               | Standalone minified token layer.         |
+| `@marcomattes/epaper-components/base.min.css`                  | `dist/styles/base.min.css`                 | Standalone minified reset.               |
+| `@marcomattes/epaper-components/components.min.css`            | `dist/styles/components.min.css`           | Standalone minified component CSS.       |
 
 The minified files are produced by [`cssnano`](https://cssnano.github.io/cssnano/)
 (see [scripts/build-css.mjs](scripts/build-css.mjs)) during `npm run build`, and
@@ -345,14 +347,16 @@ each one ships with a sibling `*.min.css.map`. Importing the unminified sources
 keeps them readable and allows them to pass through a consumer's own PostCSS
 pipeline.
 
-Sizes as of the 1.0.1 build:
+Sizes as of the current 1.0.1 build:
 
-| File                 |     raw |   gzip |
-| -------------------- | ------: | -----: |
-| `tokens.min.css`     |  1.6 KB | 0.7 KB |
-| `base.min.css`       |  1.4 KB | 0.6 KB |
-| `components.min.css` | 40.5 KB | 6.3 KB |
-| `epaper.min.css`     | 43.5 KB | 7.0 KB |
+| File                         |     raw |   gzip |
+| ---------------------------- | ------: | -----: |
+| `tokens.min.css`             |  1.8 KB | 0.7 KB |
+| `base.min.css`               |  1.5 KB | 0.6 KB |
+| `components.min.css`         | 46.7 KB | 7.2 KB |
+| `epaper.min.css`             | 49.8 KB | 7.9 KB |
+| `mono-high-contrast.min.css` |  0.7 KB | 0.3 KB |
+| `kaleido.min.css`            |  0.4 KB | 0.3 KB |
 
 ## Subpath imports and bundle size
 
@@ -366,9 +370,9 @@ in Vite, Rollup, esbuild and webpack 5.
 Compound elements that a parent component registers alongside itself — such as
 `<e-form-item>` (registered by `form.ts`) or `<e-option>` (registered by
 `select.ts`) — do not get their own subpath; importing the parent module
-registers them too. `package.json` exposes 84 subpaths in total: the barrel,
-69 component entries covering all 89 tags between them, and 14 CSS/source-map
-entries.
+registers them too. `package.json` exposes 92 subpaths in total: the barrel,
+65 component entries covering all 89 tags between them, three core-helper
+entries, 22 CSS/source-map entries and the Custom Elements Manifest.
 
 | Goal               | Import                                                           |
 | ------------------ | ---------------------------------------------------------------- |
@@ -376,24 +380,23 @@ entries.
 | Type imports only  | `import type { EButton } from '@marcomattes/epaper-components';` |
 | Whole library      | `import '@marcomattes/epaper-components';`                       |
 
-Bundling the full library through esbuild produces about 31.6 KB brotli, or
-roughly 37 KB gzip; `npm run size` enforces a 40 KB brotli budget on the barrel
-and separate budgets on `<e-button>` (6 KB, currently 909 B) and `<e-input>`
-(8 KB, currently 1.43 KB). The CSS files are declared as having side effects,
-since they apply globally, and are never tree-shaken.
+Bundling the full library through esbuild currently produces 36.17 KB brotli;
+`npm run size` enforces a 40 KB brotli budget on the barrel and separate budgets
+on `<e-button>` (6 KB, currently 909 B) and `<e-input>` (8 KB, currently
+1.78 KB). The CSS files are declared as having side effects, since they apply
+globally, and are never tree-shaken.
 
 ## Forms
 
 Every interactive control is a [form-associated custom
 element](https://web.dev/articles/more-capable-form-controls). Giving a control
 a `name` attribute is enough for it to participate in submission, `FormData`
-and `form.reset()`. Built-in constraint validation — a `required` field
-reporting itself invalid and blocking submission — is currently only wired up
-for `<e-input>`, `<e-textarea>` (value/pattern rules) and `<e-upload>` (file
-constraints); the other ten `BaseFormControl` subclasses accept `required` and
-render it, but never call `ElementInternals.setValidity()`, so it has no effect
-on `checkValidity()` or submission for those controls today. `form.reset()`
-restores every control's `default-value` attribute (or `default-checked` for
+and `form.reset()`. Built-in constraint validation is shared by all thirteen
+`BaseFormControl` subclasses: `required` reports `valueMissing` for empty text,
+selection and file controls (and for unchecked checkbox/toggle controls), while
+the text and number controls also mirror their native input constraints through
+`ElementInternals.setValidity()`. `form.reset()` restores every control's
+`default-value` attribute (or `default-checked` for
 `<e-checkbox>`/`<e-toggle>`/`<e-radio>`), not its initial `value`.
 
 ```html
@@ -662,7 +665,7 @@ the current release.
 src/
   core/        # Cross-cutting helpers: dom, icons, base-form-control, types.
   components/  # One web component per file. Each calls define(...) at module scope.
-  styles/      # tokens.css, base.css, components.css. Public CSS surface.
+  styles/      # Base CSS layers and optional panel themes. Public CSS surface.
   stories/     # Storybook documentation; not shipped.
   site/        # Source of epaper-components.dev; not shipped.
   demo/        # Demo HTML wiring; not shipped.
@@ -687,6 +690,7 @@ npm run dev               # Vite playground (src/demo) on http://localhost:8085
 npm run storybook         # Storybook on :6006
 npm run test              # Vitest in watch mode (browser/Chromium via Playwright)
 npm run test:ci           # Vitest single run, CI-friendly
+npm run test:refresh      # E-paper mutation and dirty-area budgets
 npm run test:coverage     # Watch mode + v8 coverage report
 npm run test:coverage:ci  # Single run + v8 coverage report
 npm run test-storybook    # Run Storybook a11y/interaction tests
@@ -711,9 +715,10 @@ npm run validate:sample-app:types  # this README's TypeScript snippets, strict-c
 1. **`vite build`** emits per-component ES modules to `dist/components/*.js`, the
    barrel `dist/index.js` and shared chunks under `dist/chunks/`, each with a
    source map.
-2. **`node scripts/build-css.mjs`** copies `src/styles/*.css` to `dist/styles/`,
-   runs them through `cssnano`, writes `*.min.css` plus `*.min.css.map`, and
-   concatenates the three layers into `dist/styles/epaper.min.css`.
+2. **`node scripts/build-css.mjs`** copies the base layers and optional themes
+   from `src/styles/` to `dist/styles/`, runs them through `cssnano`, writes
+   `*.min.css` plus `*.min.css.map`, and concatenates the three base layers into
+   `dist/styles/epaper.min.css`.
 3. **`tsc -p tsconfig.build.json`** emits the `.d.ts` files into `dist/`.
 4. **`cem analyze` and `node scripts/gen-tag-map.mjs`** produce
    `dist/custom-elements.json`, `dist/web-types.json`,

--- a/THEMING.md
+++ b/THEMING.md
@@ -51,6 +51,37 @@ For per-instance tweaks, set custom properties on the element:
 > override are listed in the reference table below. Per-component CSS variables
 > are planned but not yet available.
 
+## Panel theme packs
+
+Two optional theme packs ship as plain CSS. Import one after `tokens.css`, then
+activate it on the document root or scope it to a container:
+
+```css
+@import '@marcomattes/epaper-components/tokens.css';
+@import '@marcomattes/epaper-components/themes/mono-high-contrast.css';
+@import '@marcomattes/epaper-components/base.css';
+@import '@marcomattes/epaper-components/components.css';
+```
+
+```html
+<html data-ink-theme="mono-high-contrast">
+  <!-- application -->
+</html>
+
+<section class="ink-theme--kaleido ink-page">
+  <!-- a Kaleido-scoped preview -->
+</section>
+```
+
+`mono-high-contrast` increases border, focus and control-size tokens while
+remaining strictly black and white. `kaleido` maps semantic accent, info,
+success, warning and danger tokens to the five-color panel palette. Color is
+always secondary: status components retain their icon, border-weight and hatch
+cues so they remain meaningful on a one-bit panel.
+
+Minified builds are available as
+`themes/mono-high-contrast.min.css` and `themes/kaleido.min.css`.
+
 ## Token reference
 
 All tokens are defined in `tokens.css` on `:root`.
@@ -99,16 +130,22 @@ All tokens are defined in `tokens.css` on `:root`.
 
 ### Color
 
-| Token               | Default | Description                |
-| ------------------- | ------- | -------------------------- |
-| `--ink-fg`          | `#000`  | Foreground (text, borders) |
-| `--ink-bg`          | `#fff`  | Background                 |
-| `--ink-fg-inverted` | `#fff`  | Inverted foreground        |
-| `--ink-bg-inverted` | `#000`  | Inverted background        |
+| Token               | Default    | Description                 |
+| ------------------- | ---------- | --------------------------- |
+| `--ink-fg`          | `#000`     | Foreground (text, borders)  |
+| `--ink-bg`          | `#fff`     | Background                  |
+| `--ink-fg-inverted` | `#fff`     | Inverted foreground         |
+| `--ink-bg-inverted` | `#000`     | Inverted background         |
+| `--ink-accent`      | foreground | Progress and general accent |
+| `--ink-info`        | foreground | Informational status        |
+| `--ink-success`     | foreground | Success status              |
+| `--ink-warning`     | foreground | Warning status              |
+| `--ink-danger`      | foreground | Error/destructive status    |
 
-Kaleido accent colors (`--kaleido-red`, `--kaleido-orange`, `--kaleido-yellow`,
-`--kaleido-green`, `--kaleido-blue`) are available but reserved for status
-indicators. They render as flat fills — no gradients.
+The semantic colors default to `--ink-fg`, so the base theme remains strictly
+monochrome. The Kaleido theme maps them to `--kaleido-red`,
+`--kaleido-orange`, `--kaleido-green` and `--kaleido-blue`. They render as flat
+fills or two-color hatch patterns, never blended gradients.
 
 ### Borders
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,11 @@
     "./src/components/*.ts",
     "./src/site/*.ts",
     "./src/styles/*.css",
+    "./src/styles/themes/*.css",
     "./dist/styles/*.css",
-    "./dist/styles/*.min.css"
+    "./dist/styles/*.min.css",
+    "./dist/styles/themes/*.css",
+    "./dist/styles/themes/*.min.css"
   ],
   "exports": {
     ".": {
@@ -328,13 +331,21 @@
     "./styles/tokens.css": "./src/styles/tokens.css",
     "./styles/base.css": "./src/styles/base.css",
     "./styles/components.css": "./src/styles/components.css",
+    "./themes/mono-high-contrast.css": "./src/styles/themes/mono-high-contrast.css",
+    "./themes/kaleido.css": "./src/styles/themes/kaleido.css",
+    "./styles/themes/mono-high-contrast.css": "./src/styles/themes/mono-high-contrast.css",
+    "./styles/themes/kaleido.css": "./src/styles/themes/kaleido.css",
     "./tokens.min.css": "./dist/styles/tokens.min.css",
     "./base.min.css": "./dist/styles/base.min.css",
     "./components.min.css": "./dist/styles/components.min.css",
+    "./themes/mono-high-contrast.min.css": "./dist/styles/themes/mono-high-contrast.min.css",
+    "./themes/kaleido.min.css": "./dist/styles/themes/kaleido.min.css",
     "./styles.min.css": "./dist/styles/epaper.min.css",
     "./tokens.min.css.map": "./dist/styles/tokens.min.css.map",
     "./base.min.css.map": "./dist/styles/base.min.css.map",
     "./components.min.css.map": "./dist/styles/components.min.css.map",
+    "./themes/mono-high-contrast.min.css.map": "./dist/styles/themes/mono-high-contrast.min.css.map",
+    "./themes/kaleido.min.css.map": "./dist/styles/themes/kaleido.min.css.map",
     "./styles.min.css.map": "./dist/styles/epaper.min.css.map",
     "./custom-elements.json": "./dist/custom-elements.json"
   },
@@ -382,6 +393,7 @@
     "test-storybook": "vitest --project=storybook",
     "test:visual": "vitest run src/components/__tests__/screenshots.test.ts",
     "test:visual:update": "npm run test:visual -- --update",
+    "test:refresh": "vitest run src/components/__tests__/refresh-budget.test.ts",
     "test:browserstack": "node scripts/browserstack-test.mjs",
     "test:coverage": "vitest --coverage",
     "test:coverage:ci": "vitest run --coverage",

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import postcss from 'postcss';
 import cssnano from 'cssnano';
 
 const distStylesDir = resolve('dist/styles');
 const srcStylesDir = resolve('src/styles');
 
-const cssFiles = ['tokens.css', 'base.css', 'components.css'];
+const coreCssFiles = ['tokens.css', 'base.css', 'components.css'];
+const themeCssFiles = ['themes/mono-high-contrast.css', 'themes/kaleido.css'];
+const cssFiles = [...coreCssFiles, ...themeCssFiles];
 
 async function buildCSS() {
   // Create dist/styles directory
@@ -28,6 +30,7 @@ async function buildCSS() {
     const srcPath = join(srcStylesDir, file);
     const distPath = join(distStylesDir, file);
     const minPath = join(distStylesDir, file.replace('.css', '.min.css'));
+    mkdirSync(dirname(distPath), { recursive: true });
 
     // Read source file
     const source = readFileSync(srcPath, 'utf-8');
@@ -56,7 +59,7 @@ async function buildCSS() {
   console.log('\n');
 
   // 2. Create combined bundle
-  const allCSS = cssFiles
+  const allCSS = coreCssFiles
     .map((file) => {
       const srcPath = join(srcStylesDir, file);
       return readFileSync(srcPath, 'utf-8');
@@ -88,6 +91,10 @@ async function buildCSS() {
   console.log('  - dist/styles/base.min.css (+.map)');
   console.log('  - dist/styles/components.css');
   console.log('  - dist/styles/components.min.css (+.map)');
+  console.log('  - dist/styles/themes/mono-high-contrast.css');
+  console.log('  - dist/styles/themes/mono-high-contrast.min.css (+.map)');
+  console.log('  - dist/styles/themes/kaleido.css');
+  console.log('  - dist/styles/themes/kaleido.min.css (+.map)');
   console.log('  - dist/styles/epaper.min.css (+.map)');
 }
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -83,6 +83,8 @@ check('public asset subpaths resolve to real files', () => {
     '/tokens.css',
     '/base.css',
     '/components.css',
+    '/themes/mono-high-contrast.css',
+    '/themes/kaleido.css',
     '/custom-elements.json',
     '/core/dom',
   ];

--- a/src/components/__tests__/form-association.test.ts
+++ b/src/components/__tests__/form-association.test.ts
@@ -438,4 +438,138 @@ describe('form association', () => {
     expect(up.value).toHaveLength(1);
     expect(up.value[0].name).toBe('x.txt');
   });
+
+  const requiredCases: Array<{
+    name: string;
+    html: string;
+    satisfy: (control: HTMLElement) => void;
+  }> = [
+    {
+      name: 'e-input',
+      html: '<e-input name="v" required></e-input>',
+      satisfy: (el) => el.setAttribute('value', 'Ada'),
+    },
+    {
+      name: 'e-textarea',
+      html: '<e-textarea name="v" required></e-textarea>',
+      satisfy: (el) => el.setAttribute('value', 'Notes'),
+    },
+    {
+      name: 'e-checkbox',
+      html: '<e-checkbox name="v" required></e-checkbox>',
+      satisfy: (el) => el.setAttribute('checked', ''),
+    },
+    {
+      name: 'e-toggle',
+      html: '<e-toggle name="v" required></e-toggle>',
+      satisfy: (el) => el.setAttribute('checked', ''),
+    },
+    {
+      name: 'e-select',
+      html: '<e-select name="v" required><e-option value="a" label="A"></e-option></e-select>',
+      satisfy: (el) => el.setAttribute('value', 'a'),
+    },
+    {
+      name: 'e-radio-group',
+      html: '<e-radio-group name="v" required><e-radio value="a" label="A"></e-radio></e-radio-group>',
+      satisfy: (el) => el.setAttribute('value', 'a'),
+    },
+    {
+      name: 'e-checkbox-group',
+      html: '<e-checkbox-group name="v" required><e-cbox-option value="a" label="A"></e-cbox-option></e-checkbox-group>',
+      satisfy: (el) => el.setAttribute('value', 'a'),
+    },
+    {
+      name: 'e-input-number',
+      html: '<e-input-number name="v" required></e-input-number>',
+      satisfy: (el) => el.setAttribute('value', '1'),
+    },
+    {
+      name: 'e-date-picker',
+      html: '<e-date-picker name="v" required></e-date-picker>',
+      satisfy: (el) => el.setAttribute('value', '2026-08-17'),
+    },
+    {
+      name: 'e-cascader',
+      html: '<e-cascader name="v" required data=\'[{"value":"a","label":"A"}]\'></e-cascader>',
+      satisfy: (el) => el.setAttribute('value', 'a'),
+    },
+    {
+      name: 'e-tree-select',
+      html: '<e-tree-select name="v" required data=\'[{"value":"a","label":"A"}]\'></e-tree-select>',
+      satisfy: (el) => el.setAttribute('value', 'a'),
+    },
+    {
+      name: 'e-upload',
+      html: '<e-upload name="v" required></e-upload>',
+      satisfy: (el) => {
+        (el as HTMLElement & { value: File[] }).value = [new File(['a'], 'a.txt')];
+      },
+    },
+  ];
+
+  for (const testCase of requiredCases) {
+    it(`${testCase.name} mirrors required through ElementInternals`, () => {
+      const form = mount(`<form>${testCase.html}</form>`);
+      const control = form.firstElementChild as HTMLElement & { checkValidity(): boolean };
+      expect(control.checkValidity()).toBe(false);
+      expect(form.checkValidity()).toBe(false);
+      testCase.satisfy(control);
+      expect(control.checkValidity()).toBe(true);
+      expect(form.checkValidity()).toBe(true);
+    });
+  }
+
+  it('e-time-picker has a valid required default of 00:00', () => {
+    const form = mount('<form><e-time-picker name="v" required></e-time-picker></form>');
+    const control = form.firstElementChild as HTMLElement & {
+      value: string;
+      checkValidity(): boolean;
+    };
+    expect(control.value).toBe('00:00');
+    expect(control.checkValidity()).toBe(true);
+  });
+
+  it('e-input-number mirrors native range constraints', () => {
+    const form = mount('<form><e-input-number name="v" value="2" min="3"></e-input-number></form>');
+    const control = form.firstElementChild as HTMLElement & { checkValidity(): boolean };
+    expect(control.checkValidity()).toBe(false);
+    control.setAttribute('value', '3');
+    expect(control.checkValidity()).toBe(true);
+  });
+
+  it('e-input-number updates host validity while the user edits', () => {
+    const form = mount(
+      '<form><e-input-number name="v" value="1" required></e-input-number></form>',
+    );
+    const control = form.firstElementChild as HTMLElement & { checkValidity(): boolean };
+    const input = control.querySelector('input')!;
+    expect(control.checkValidity()).toBe(true);
+    input.value = '';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(control.checkValidity()).toBe(false);
+  });
+
+  it('e-input sanitizes native typed values before form submission', () => {
+    const form = mount(
+      '<form><e-input name="v" type="number" value="not-a-number" required></e-input></form>',
+    );
+    const control = form.firstElementChild as HTMLElement & {
+      value: string;
+      checkValidity(): boolean;
+    };
+    expect(control.value).toBe('');
+    expect(new FormData(form as HTMLFormElement).get('v')).toBe('');
+    expect(control.checkValidity()).toBe(false);
+  });
+
+  it('required-message overrides the default component message', () => {
+    const form = mount(
+      '<form><e-checkbox required required-message="Accept the terms"></e-checkbox></form>',
+    );
+    const control = form.firstElementChild as HTMLElement & {
+      validationMessage: string;
+    };
+    expect(control.validationMessage).toBe('Accept the terms');
+  });
 });

--- a/src/components/__tests__/refresh-budget.test.ts
+++ b/src/components/__tests__/refresh-budget.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import '../../styles/tokens.css';
+import '../../styles/base.css';
+import '../../styles/components.css';
+
+interface RefreshMeasurement {
+  mutationCount: number;
+  elementChurn: number;
+  rootReplacements: number;
+  retainedNodeRatio: number;
+  dirtyAreaRatio: number;
+}
+
+interface RefreshBudget {
+  mutations: number;
+  elementChurn: number;
+  dirtyAreaRatio: number;
+  retainedNodeRatio?: number;
+}
+
+interface RefreshScenario {
+  name: string;
+  html: string;
+  selector: string;
+  action: (host: HTMLElement) => void;
+  budget: RefreshBudget;
+}
+
+beforeAll(async () => {
+  await Promise.all([
+    import('../progress'),
+    import('../time-picker'),
+    import('../table'),
+    import('../select'),
+    import('../tabs'),
+  ]);
+});
+
+afterEach(() => {
+  document.querySelectorAll('[data-refresh-fixture]').forEach((node) => node.remove());
+});
+
+const nextFrame = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+async function mount(html: string, selector: string): Promise<HTMLElement> {
+  const fixture = document.createElement('div');
+  fixture.dataset['refreshFixture'] = '';
+  fixture.className = 'ink-page';
+  fixture.style.cssText = 'display:block;width:640px;padding:16px;';
+  fixture.innerHTML = html;
+  document.body.appendChild(fixture);
+  await nextFrame();
+  return fixture.querySelector<HTMLElement>(selector)!;
+}
+
+function clippedRect(element: Element, bounds: DOMRect): DOMRect | null {
+  const rect = element.getBoundingClientRect();
+  const left = Math.max(bounds.left, rect.left);
+  const top = Math.max(bounds.top, rect.top);
+  const right = Math.min(bounds.right, rect.right);
+  const bottom = Math.min(bounds.bottom, rect.bottom);
+  if (right <= left || bottom <= top) return null;
+  return new DOMRect(left, top, right - left, bottom - top);
+}
+
+async function measureRefresh(host: HTMLElement, action: () => void): Promise<RefreshMeasurement> {
+  const before = new Set(host.querySelectorAll('*'));
+  const records: MutationRecord[] = [];
+  const observer = new MutationObserver((batch) => records.push(...batch));
+  observer.observe(host, {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+  });
+
+  action();
+  await Promise.resolve();
+  await nextFrame();
+  records.push(...observer.takeRecords());
+  observer.disconnect();
+
+  let elementChurn = 0;
+  let rootReplacements = 0;
+  const dirtyElements = new Set<Element>();
+  for (const record of records) {
+    const addedElements = [...record.addedNodes].filter((node) => node instanceof Element).length;
+    const removedElements = [...record.removedNodes].filter(
+      (node) => node instanceof Element,
+    ).length;
+    elementChurn += addedElements + removedElements;
+    if (
+      record.type === 'childList' &&
+      record.target === host &&
+      (addedElements || removedElements)
+    ) {
+      rootReplacements++;
+    }
+    if (record.target instanceof Element && record.target !== host) {
+      dirtyElements.add(record.target);
+    } else if (
+      !(record.target instanceof Element) &&
+      record.target.parentElement &&
+      record.target.parentElement !== host
+    ) {
+      dirtyElements.add(record.target.parentElement);
+    }
+  }
+
+  const retained = [...before].filter((node) => host.contains(node)).length;
+  const retainedNodeRatio = before.size === 0 ? 1 : retained / before.size;
+  const hostRect = host.getBoundingClientRect();
+  const rects = [...dirtyElements]
+    .map((element) => clippedRect(element, hostRect))
+    .filter((rect): rect is DOMRect => rect !== null);
+
+  let dirtyAreaRatio = 0;
+  if (rects.length > 0 && hostRect.width > 0 && hostRect.height > 0) {
+    const left = Math.min(...rects.map((rect) => rect.left));
+    const top = Math.min(...rects.map((rect) => rect.top));
+    const right = Math.max(...rects.map((rect) => rect.right));
+    const bottom = Math.max(...rects.map((rect) => rect.bottom));
+    dirtyAreaRatio = ((right - left) * (bottom - top)) / (hostRect.width * hostRect.height);
+  }
+
+  return {
+    mutationCount: records.length,
+    elementChurn,
+    rootReplacements,
+    retainedNodeRatio,
+    dirtyAreaRatio,
+  };
+}
+
+const scenarios: RefreshScenario[] = [
+  {
+    name: 'progress value update',
+    html: '<e-progress value="20" label="Sync"></e-progress>',
+    selector: 'e-progress',
+    action: (host) => host.setAttribute('value', '45'),
+    // The bar and visible percentage caption both change, spanning almost the
+    // whole (small) component even though each update is surgical.
+    budget: { mutations: 5, elementChurn: 0, dirtyAreaRatio: 0.95 },
+  },
+  {
+    name: 'time-picker value update',
+    html: '<e-time-picker value="09:30"></e-time-picker>',
+    selector: 'e-time-picker',
+    action: (host) => host.setAttribute('value', '10:45'),
+    budget: { mutations: 7, elementChurn: 0, dirtyAreaRatio: 0.75 },
+  },
+  {
+    name: 'table row selection',
+    html: '<e-table selectable columns=\'[{"key":"title","title":"Title"}]\' data=\'[{"title":"A"},{"title":"B"},{"title":"C"}]\'></e-table>',
+    selector: 'e-table',
+    action: (host) => host.setAttribute('selected', '0'),
+    budget: { mutations: 4, elementChurn: 0, dirtyAreaRatio: 0.5 },
+  },
+  {
+    name: 'select option update',
+    html: '<e-select value="a"><e-option value="a" label="A"></e-option><e-option value="b" label="B"></e-option></e-select>',
+    selector: 'e-select',
+    action: (host) => host.setAttribute('value', 'b'),
+    budget: {
+      mutations: 10,
+      elementChurn: 2,
+      dirtyAreaRatio: 0.6,
+      retainedNodeRatio: 0.8,
+    },
+  },
+  {
+    name: 'tab activation',
+    html: '<e-tabs default-value="a"><e-tab key="a" label="A">Alpha</e-tab><e-tab key="b" label="B">Beta</e-tab></e-tabs>',
+    selector: 'e-tabs',
+    action: (host) => host.querySelectorAll<HTMLButtonElement>('[role="tab"]')[1]?.click(),
+    budget: { mutations: 10, elementChurn: 0, dirtyAreaRatio: 1 },
+  },
+];
+
+describe('e-paper refresh budgets', () => {
+  for (const scenario of scenarios) {
+    it(`${scenario.name} stays within its mutation and dirty-area budget`, async () => {
+      const host = await mount(scenario.html, scenario.selector);
+      const result = await measureRefresh(host, () => scenario.action(host));
+
+      expect(result.rootReplacements, 'host subtree replacements').toBe(0);
+      expect(result.mutationCount, 'DOM mutation count').toBeLessThanOrEqual(
+        scenario.budget.mutations,
+      );
+      expect(result.elementChurn, 'added + removed element nodes').toBeLessThanOrEqual(
+        scenario.budget.elementChurn,
+      );
+      expect(result.retainedNodeRatio, 'retained descendant identity').toBeGreaterThanOrEqual(
+        scenario.budget.retainedNodeRatio ?? 0.9,
+      );
+      expect(result.dirtyAreaRatio, 'approximated dirty rectangle / host area').toBeLessThanOrEqual(
+        scenario.budget.dirtyAreaRatio,
+      );
+    });
+  }
+});

--- a/src/components/__tests__/theme-packs.test.ts
+++ b/src/components/__tests__/theme-packs.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import '../../styles/tokens.css';
+import '../../styles/components.css';
+import '../../styles/themes/mono-high-contrast.css';
+import '../../styles/themes/kaleido.css';
+
+beforeAll(async () => {
+  await import('../alert');
+});
+
+afterEach(() => {
+  document.querySelectorAll('[data-theme-test]').forEach((node) => node.remove());
+});
+
+const token = (element: Element, name: string): string =>
+  getComputedStyle(element).getPropertyValue(name).trim();
+
+describe('panel theme packs', () => {
+  it('scopes the high-contrast monochrome tokens to a container', () => {
+    const outer = document.createElement('div');
+    outer.dataset['themeTest'] = '';
+    outer.className = 'ink-page';
+    const themed = document.createElement('section');
+    themed.className = 'ink-theme--mono-high-contrast';
+    outer.appendChild(themed);
+    document.body.appendChild(outer);
+
+    expect(token(outer, '--ink-border-width')).toBe('2px');
+    expect(token(themed, '--ink-border-width')).toBe('3px');
+    expect(token(themed, '--ink-focus-width')).toBe('4px');
+    expect(token(themed, '--ink-control-h-md')).toBe('48px');
+    expect(token(themed, '--ink-accent')).toBe('#000');
+  });
+
+  it('maps Kaleido status tokens without removing non-color error cues', () => {
+    const root = document.createElement('div');
+    root.dataset['themeTest'] = '';
+    root.dataset['inkTheme'] = 'kaleido';
+    root.className = 'ink-page';
+    root.innerHTML = '<e-alert variant="error" heading="Failure"></e-alert>';
+    document.body.appendChild(root);
+
+    const alert = root.querySelector<HTMLElement>('.ink-alert')!;
+    expect(token(root, '--ink-success')).toBe('#1f8a3b');
+    expect(token(root, '--ink-warning')).toBe('#e26a1b');
+    expect(token(root, '--ink-danger')).toBe('#d11a1a');
+    expect(getComputedStyle(alert).borderColor).toBe('rgb(209, 26, 26)');
+    expect(getComputedStyle(alert.querySelector('.ink-alert__icon')!).backgroundImage).not.toBe(
+      'none',
+    );
+  });
+});

--- a/src/components/affix.ts
+++ b/src/components/affix.ts
@@ -2,6 +2,7 @@ import { define, numAttr } from '../core/dom';
 
 /**
  * @summary Wraps slotted content in a `position: sticky` container.
+ * @since v1.0.1
  *
  * Use to keep a sidebar, toolbar or header pinned while the page scrolls.
  * Implementation is pure CSS sticky — no scroll listeners — so it never

--- a/src/components/alert.ts
+++ b/src/components/alert.ts
@@ -22,6 +22,7 @@ const roleFor = (variant: Variant): string => (variant === 'error' ? 'alert' : '
 
 /**
  * @summary Inline status banner for a message attached to a region of the page.
+ * @since v1.1.0
  *
  * The static counterpart to a toast: nothing appears or disappears on a timer,
  * because an auto-dismissing message can be missed entirely between two panel

--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -11,6 +11,7 @@ import {
 
 /**
  * @summary In-page navigation that highlights the current section while scrolling.
+ * @since v1.0.1
  *
  * Reads its items from child `<e-anchor-item>` elements at connect time.
  *

--- a/src/components/avatar.ts
+++ b/src/components/avatar.ts
@@ -9,6 +9,7 @@ import {
 
 /**
  * @summary User avatar with image or initials fallback.
+ * @since v1.0.1
  *
  * @attr {string} [name='?'] - Display name; the first one or two initials are rendered when no image is supplied.
  * @attr {string} [src] - Image URL. When set, replaces the initials.

--- a/src/components/back-top.ts
+++ b/src/components/back-top.ts
@@ -3,6 +3,7 @@ import { iconSvg } from '../core/icons';
 
 /**
  * @summary Floating button that scrolls the window (or a target) to the top.
+ * @since v1.0.1
  *
  * Hidden until the scroll position passes `visibility-height`. Click triggers
  * `window.scrollTo({ top: 0 })`. Position defaults to bottom-right but can

--- a/src/components/badge-count.ts
+++ b/src/components/badge-count.ts
@@ -2,6 +2,7 @@ import { boolAttr, captureWrap, define, intAttr, patchAttr, patchText } from '..
 
 /**
  * @summary Numeric or dot indicator overlaid on a child element.
+ * @since v1.0.1
  *
  * Wraps its children and decorates them with a count chip in the corner.
  *

--- a/src/components/badge.ts
+++ b/src/components/badge.ts
@@ -2,6 +2,7 @@ import { boolAttr, captureWrap, define, patchClassModifier } from '../core/dom';
 
 /**
  * @summary Inline label badge with an optional inverted color treatment.
+ * @since v1.0.1
  *
  * Children are used as the badge text.
  *

--- a/src/components/breadcrumb.ts
+++ b/src/components/breadcrumb.ts
@@ -2,6 +2,7 @@ import { define, patchText } from '../core/dom';
 
 /**
  * @summary Hierarchical navigation trail rendered from `<e-breadcrumb-item>` children.
+ * @since v1.0.1
  *
  * @attr {string} [separator='/'] - Glyph rendered between entries.
  *

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -2,6 +2,7 @@ import { boolAttr, define, patchBoolAttr, patchClassModifier } from '../core/dom
 
 /**
  * @summary Primary button with three visual variants.
+ * @since v1.0.1
  *
  * Children are used as the button label.
  *

--- a/src/components/calendar.ts
+++ b/src/components/calendar.ts
@@ -9,6 +9,7 @@ const CELL_COUNT = 42;
 
 /**
  * @summary Month-grid calendar with selectable day cells and inline event chips.
+ * @since v1.0.1
  *
  * @attr {string} [value] - Currently selected day in `YYYY-MM-DD` format.
  * @attr {string} [events='[]'] - JSON-encoded array of `{date, title}` event objects.

--- a/src/components/card-image.ts
+++ b/src/components/card-image.ts
@@ -2,6 +2,7 @@ import { define, esc, patchClassModifier, patchText } from '../core/dom';
 
 /**
  * @summary Card variant with a top cover area and optional footer slot.
+ * @since v1.0.1
  *
  * @attr {string} [title] - Title rendered in the header.
  * @attr {string} [eyebrow] - Small label rendered above the title.

--- a/src/components/card.ts
+++ b/src/components/card.ts
@@ -2,6 +2,7 @@ import { define, patchText } from '../core/dom';
 
 /**
  * @summary Container with optional eyebrow, title and action area.
+ * @since v1.0.1
  *
  * @attr {string} [title] - Title rendered in the header.
  * @attr {string} [eyebrow] - Small label rendered above the title.

--- a/src/components/cascader.md
+++ b/src/components/cascader.md
@@ -12,20 +12,22 @@ Form-associated: submits the current path joined with `,`.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Comma-separated value path (e.g. `a,b,c`). |
-| `data` | `string` | `'[]'` | JSON-encoded array of `{value, label, children?}` nodes. Canonical attribute, shared with `<e-tree-select>`. |
-| `options` | `string` | `'[]'` | Legacy alias for `data`. When both are set, `data` wins. |
-| `placeholder` | `string` | `'Select…'` | Placeholder shown when no value is selected. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default     | Description                                                                                                  |
+| ------------------ | --------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `value`            | `string`  | —           | Comma-separated value path (e.g. `a,b,c`).                                                                   |
+| `data`             | `string`  | `'[]'`      | JSON-encoded array of `{value, label, children?}` nodes. Canonical attribute, shared with `<e-tree-select>`. |
+| `options`          | `string`  | `'[]'`      | Legacy alias for `data`. When both are set, `data` wins.                                                     |
+| `placeholder`      | `string`  | `'Select…'` | Placeholder shown when no value is selected.                                                                 |
+| `required`         | `boolean` | —           | Requires a completed selection path.                                                                         |
+| `required-message` | `string`  | —           | Message reported when no required path is selected.                                                          |
+| `name`             | `string`  | —           | Form field name. Required to participate in `FormData`.                                                      |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `e-error` | `CustomEvent<{error: Error, source: 'data' \| 'options'}>` | Fired when the `data` or `options` attribute fails to parse as JSON. The internal options list falls back to `[]`. |
-| `e-change` | `CustomEvent<{value: string[]}>` | Fired when a leaf node is selected. `value` is the path of node values. |
+| Event      | Detail                                                     | Description                                                                                                        |
+| ---------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `e-error`  | `CustomEvent<{error: Error, source: 'data' \| 'options'}>` | Fired when the `data` or `options` attribute fails to parse as JSON. The internal options list falls back to `[]`. |
+| `e-change` | `CustomEvent<{value: string[]}>`                           | Fired when a leaf node is selected. `value` is the path of node values.                                            |
 
 ## Slots
 
@@ -33,6 +35,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/cascader.ts
+++ b/src/components/cascader.ts
@@ -6,6 +6,7 @@ import { isTreeData } from '../core/data';
 
 /**
  * @summary Multi-column cascading selector for hierarchical options.
+ * @since v1.0.1
  *
  * Form-associated: submits the current path joined with `,`.
  *
@@ -14,6 +15,8 @@ import { isTreeData } from '../core/data';
  * @attr {string} [options='[]'] - Legacy alias for `data`. When both are set, `data` wins.
  * @attr {string} [value] - Comma-separated value path (e.g. `a,b,c`).
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
+ * @attr {boolean} [required] - Requires a completed selection path.
+ * @attr {string} [required-message] - Message reported when no required path is selected.
  *
  * @fires {CustomEvent<{value: string[]}>} e-change - Fired when a leaf node is selected. `value` is the path of node values.
  * @fires {CustomEvent<{error: Error, source: 'data' | 'options'}>} e-error - Fired when the `data` or `options` attribute fails to parse as JSON. The internal options list falls back to `[]`.
@@ -22,7 +25,14 @@ import { isTreeData } from '../core/data';
  * <e-cascader data='[{"value":"eu","label":"Europe","children":[{"value":"de","label":"Germany"}]}]' value="eu,de"></e-cascader>
  */
 export class ECascader extends BaseFormControl {
-  static observedAttributes = ['value', 'data', 'options', 'placeholder'];
+  static observedAttributes = [
+    'value',
+    'data',
+    'options',
+    'placeholder',
+    'required',
+    'required-message',
+  ];
 
   private _options: CascaderOption[] = [];
   private _path: string[] = [];
@@ -41,6 +51,7 @@ export class ECascader extends BaseFormControl {
       this._build();
       this._syncMenu();
       this._syncTrigger();
+      this._syncValidity();
     }
     this._bindEvents();
   }
@@ -56,14 +67,18 @@ export class ECascader extends BaseFormControl {
       this._colKeys = [];
       this._syncMenu();
       this._syncTrigger();
+      this._syncValidity();
     } else if (name === 'value') {
       this._path = (val || '').split(',').filter(Boolean);
       this._value = this._path.join(',');
       this.internals.setFormValue(this._value);
       this._syncMenu();
       this._syncTrigger();
+      this._syncValidity();
     } else if (name === 'placeholder') {
       this._syncTrigger();
+    } else if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
     }
   }
 
@@ -371,6 +386,11 @@ export class ECascader extends BaseFormControl {
   override formResetCallback(): void {
     const dflt = this.getAttribute('default-value') ?? '';
     this.setAttribute('value', dflt);
+  }
+
+  private _syncValidity(): void {
+    this._trigger?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(!!this._value, this._trigger, 'Please select an option.');
   }
 }
 

--- a/src/components/checkbox-group.md
+++ b/src/components/checkbox-group.md
@@ -13,16 +13,18 @@ Form-associated: each selected option is appended to FormData under `name`.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Comma-separated list of selected option values. Reactive. |
-| `layout` | `'horizontal'\|'vertical'` | `'vertical'` | Stacking direction. Reactive. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type                       | Default      | Description                                               |
+| ------------------ | -------------------------- | ------------ | --------------------------------------------------------- |
+| `value`            | `string`                   | —            | Comma-separated list of selected option values. Reactive. |
+| `layout`           | `'horizontal'\|'vertical'` | `'vertical'` | Stacking direction. Reactive.                             |
+| `required`         | `boolean`                  | —            | Requires at least one selected option.                    |
+| `required-message` | `string`                   | —            | Message reported when no required option is selected.     |
+| `name`             | `string`                   | —            | Form field name. Required to participate in `FormData`.   |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                           | Description                                                                       |
+| ---------- | -------------------------------- | --------------------------------------------------------------------------------- |
 | `e-change` | `CustomEvent<{value: string[]}>` | Fired when the selection changes. `value` is the array of selected option values. |
 
 ## Slots
@@ -31,6 +33,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/checkbox-group.ts
+++ b/src/components/checkbox-group.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Group of checkbox options sharing a single comma-separated value.
+ * @since v1.0.1
  *
  * Reads options from `<e-cbox-option>` children at connect time.
  * Form-associated: each selected option is appended to FormData under `name`.
@@ -10,6 +11,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [value] - Comma-separated list of selected option values. Reactive.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {'horizontal'|'vertical'} [layout='vertical'] - Stacking direction. Reactive.
+ * @attr {boolean} [required] - Requires at least one selected option.
+ * @attr {string} [required-message] - Message reported when no required option is selected.
  *
  * @fires {CustomEvent<{value: string[]}>} e-change - Fired when the selection changes. `value` is the array of selected option values.
  *
@@ -20,7 +23,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-checkbox-group>
  */
 export class ECheckboxGroup extends BaseFormControl {
-  static observedAttributes = ['value', 'layout'];
+  static observedAttributes = ['value', 'layout', 'required', 'required-message'];
 
   private _wired = false;
   private _opts: Array<{ value: string; label: string }> = [];
@@ -30,11 +33,13 @@ export class ECheckboxGroup extends BaseFormControl {
     const name = this.getAttribute('name');
     if (!name) {
       this.internals.setFormValue(values.join(','));
+      this._syncValidity(values);
       return;
     }
     const fd = new FormData();
     for (const v of values) fd.append(name, v);
     this.internals.setFormValue(fd);
+    this._syncValidity(values);
   }
 
   connectedCallback() {
@@ -77,6 +82,8 @@ export class ECheckboxGroup extends BaseFormControl {
       if (this._container)
         this._container.style.flexDirection =
           this.getAttribute('layout') === 'horizontal' ? 'row' : 'column';
+    } else if (name === 'required' || name === 'required-message') {
+      this._syncValidity(this.value.split(',').filter(Boolean));
     }
   }
 
@@ -159,6 +166,15 @@ export class ECheckboxGroup extends BaseFormControl {
       .getAll(name)
       .filter((v): v is string => typeof v === 'string')
       .join(',');
+  }
+
+  private _syncValidity(values: string[]): void {
+    this._container?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(
+      values.length > 0,
+      this._container ?? undefined,
+      'Please select at least one option.',
+    );
   }
 }
 define('e-checkbox-group', ECheckboxGroup);

--- a/src/components/checkbox.md
+++ b/src/components/checkbox.md
@@ -13,18 +13,20 @@ matching native `<input type="checkbox">` behaviour.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `checked` | `boolean` | — | Whether the box is checked. Reflected to the attribute on user input. |
-| `label` | `string` | — | Inline text label rendered next to the box. |
-| `disabled` | `boolean` | — | Disables interaction. |
-| `value` | `string` | `'on'` | Submitted value when checked. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default | Description                                                           |
+| ------------------ | --------- | ------- | --------------------------------------------------------------------- |
+| `checked`          | `boolean` | —       | Whether the box is checked. Reflected to the attribute on user input. |
+| `label`            | `string`  | —       | Inline text label rendered next to the box.                           |
+| `disabled`         | `boolean` | —       | Disables interaction.                                                 |
+| `value`            | `string`  | `'on'`  | Submitted value when checked.                                         |
+| `required`         | `boolean` | —       | Requires the checkbox to be checked.                                  |
+| `required-message` | `string`  | —       | Message reported when the required checkbox is unchecked.             |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.               |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                            | Description                           |
+| ---------- | --------------------------------- | ------------------------------------- |
 | `e-change` | `CustomEvent<{checked: boolean}>` | Fired when the checked state changes. |
 
 ## Slots
@@ -33,7 +35,7 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `checked` | `boolean` | no |  |
-| `value` | `string` | no | Submitted value when checked (defaults to "on"). |
+| Property  | Type      | Read-only | Description                                      |
+| --------- | --------- | --------- | ------------------------------------------------ |
+| `checked` | `boolean` | no        |                                                  |
+| `value`   | `string`  | no        | Submitted value when checked (defaults to "on"). |

--- a/src/components/checkbox.ts
+++ b/src/components/checkbox.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Single checkbox with an optional inline label.
+ * @since v1.0.1
  *
  * Form-associated: submits its `value` (defaults to `"on"`) when checked,
  * matching native `<input type="checkbox">` behaviour.
@@ -12,6 +13,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [label] - Inline text label rendered next to the box.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {string} [value='on'] - Submitted value when checked.
+ * @attr {boolean} [required] - Requires the checkbox to be checked.
+ * @attr {string} [required-message] - Message reported when the required checkbox is unchecked.
  *
  * @fires {CustomEvent<{checked: boolean}>} e-change - Fired when the checked state changes.
  *
@@ -19,7 +22,14 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-checkbox checked label="Accept terms"></e-checkbox>
  */
 export class ECheckbox extends BaseFormControl {
-  static observedAttributes = ['checked', 'label', 'disabled', 'value'];
+  static observedAttributes = [
+    'checked',
+    'label',
+    'disabled',
+    'value',
+    'required',
+    'required-message',
+  ];
 
   private _wired = false;
   private _cb: HTMLInputElement | null = null;
@@ -28,6 +38,10 @@ export class ECheckbox extends BaseFormControl {
     const v = this.getAttribute('value') || 'on';
     const checked = !!this._cb?.checked;
     this.internals.setFormValue(checked ? v : null, checked ? 'checked' : 'unchecked');
+    if (this._cb) {
+      this._cb.required = boolAttr(this, 'required');
+      this.applyRequiredValidity(checked, this._cb, 'Please check this box.');
+    }
   }
 
   connectedCallback() {
@@ -68,6 +82,7 @@ export class ECheckbox extends BaseFormControl {
     }
     if (name === 'disabled') this._cb.disabled = boolAttr(this, 'disabled') || this._formDisabled;
     if (name === 'value') this._syncFormValue();
+    if (name === 'required' || name === 'required-message') this._syncFormValue();
     if (name === 'label') {
       const text = this.getAttribute('label') || '';
       const label = this.querySelector('label.ink-checkbox') as HTMLElement | null;

--- a/src/components/chip.ts
+++ b/src/components/chip.ts
@@ -2,6 +2,7 @@ import { addCleanup, boolAttr, captureWrap, define, patchBoolAttr, runCleanups }
 
 /**
  * @summary Selectable label, often used for filters or quick choices.
+ * @since v1.0.1
  *
  * Children are used as the chip text. A chip toggles `selected` on click and
  * fires `e-change`. Distinct from `<e-tag>` (which is a removable label) and

--- a/src/components/collapse.ts
+++ b/src/components/collapse.ts
@@ -10,6 +10,7 @@ interface PanelDef {
 
 /**
  * @summary Stack of expandable sections built on native `<details>`/`<summary>`.
+ * @since v1.1.0
  *
  * Reads its panels from child `<e-collapse-panel>` elements at connect time.
  * Expanding a section mutates one `open` attribute, so the EPDC repaints only

--- a/src/components/date-picker.md
+++ b/src/components/date-picker.md
@@ -12,16 +12,18 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Selected day in `YYYY-MM-DD` format. |
-| `placeholder` | `string` | `'YYYY-MM-DD'` | Trigger placeholder when no value is set. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default        | Description                                             |
+| ------------------ | --------- | -------------- | ------------------------------------------------------- |
+| `value`            | `string`  | —              | Selected day in `YYYY-MM-DD` format.                    |
+| `placeholder`      | `string`  | `'YYYY-MM-DD'` | Trigger placeholder when no value is set.               |
+| `required`         | `boolean` | —              | Requires a selected date.                               |
+| `required-message` | `string`  | —              | Message reported when no required date is selected.     |
+| `name`             | `string`  | —              | Form field name. Required to participate in `FormData`. |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                                          |
+| ---------- | ------------------------------ | ---------------------------------------------------- |
 | `e-change` | `CustomEvent<{value: string}>` | Fired when a day is picked. `value` is `YYYY-MM-DD`. |
 
 ## Slots
@@ -30,6 +32,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/date-picker.ts
+++ b/src/components/date-picker.ts
@@ -17,12 +17,15 @@ const CELL_COUNT = 42;
 
 /**
  * @summary Single-day picker with a popover month grid.
+ * @since v1.0.1
  *
  * Form-associated: participates in `<form>` submission and FormData.
  *
  * @attr {string} [value] - Selected day in `YYYY-MM-DD` format.
  * @attr {string} [placeholder='YYYY-MM-DD'] - Trigger placeholder when no value is set.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
+ * @attr {boolean} [required] - Requires a selected date.
+ * @attr {string} [required-message] - Message reported when no required date is selected.
  *
  * @fires {CustomEvent<{value: string}>} e-change - Fired when a day is picked. `value` is `YYYY-MM-DD`.
  *
@@ -30,7 +33,7 @@ const CELL_COUNT = 42;
  * <e-date-picker value="2025-04-26"></e-date-picker>
  */
 export class EDatePicker extends BaseFormControl {
-  static observedAttributes = ['value', 'placeholder'];
+  static observedAttributes = ['value', 'placeholder', 'required', 'required-message'];
 
   private _wired = false;
   private _view = { y: 2026, m: 0 };
@@ -59,6 +62,7 @@ export class EDatePicker extends BaseFormControl {
 
       this._build();
       this._patchGrid();
+      this._syncValidity();
     }
 
     this.addEventListener('click', this._onClick);
@@ -419,6 +423,8 @@ export class EDatePicker extends BaseFormControl {
       this._patchTrigger();
     } else if (name === 'value') {
       this._applyValue(val ?? '');
+    } else if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
     }
   }
 
@@ -442,6 +448,12 @@ export class EDatePicker extends BaseFormControl {
     if (parsed) this._view = { y: parsed.getFullYear(), m: parsed.getMonth() };
     this._patchTrigger();
     this._patchGrid();
+    this._syncValidity();
+  }
+
+  private _syncValidity(): void {
+    this._trigger?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(!!this._value, this._trigger ?? undefined, 'Please select a date.');
   }
 }
 

--- a/src/components/description-list.ts
+++ b/src/components/description-list.ts
@@ -2,6 +2,7 @@ import { define, intAttr } from '../core/dom';
 
 /**
  * @summary Key/value list rendered as a semantic `<dl>` grid.
+ * @since v1.0.1
  *
  * Reads entries from child `<e-desc-item>` elements at connect time. Each
  * item contributes a term/detail pair. The grid wraps after `columns`

--- a/src/components/dialog.ts
+++ b/src/components/dialog.ts
@@ -42,6 +42,7 @@ export type DialogCloseReason = 'close-button' | 'escape' | 'backdrop' | 'api';
 
 /**
  * @summary Modal dialog built on the native `<dialog>` element.
+ * @since v1.1.0
  *
  * Opens through `showModal()`, so focus trapping, `Escape` handling, the top
  * layer and inertness of the page behind it come from the browser rather than

--- a/src/components/divider.ts
+++ b/src/components/divider.ts
@@ -2,6 +2,7 @@ import { define, esc, patchAttr, patchText } from '../core/dom';
 
 /**
  * @summary Visual separator with optional label and orientation.
+ * @since v1.0.1
  *
  * @attr {'solid'|'dashed'} [variant='solid'] - Line style.
  * @attr {'horizontal'|'vertical'} [orientation='horizontal'] - Layout direction.

--- a/src/components/dropdown.ts
+++ b/src/components/dropdown.ts
@@ -9,6 +9,7 @@ type DropdownItemDef =
 
 /**
  * @summary Trigger-driven menu with items, headers and dividers.
+ * @since v1.0.1
  *
  * @attr {'left'|'right'} [align='left'] - Menu alignment relative to the trigger.
  *

--- a/src/components/empty.ts
+++ b/src/components/empty.ts
@@ -3,6 +3,7 @@ import { iconSvg } from '../core/icons';
 
 /**
  * @summary Empty-state placeholder with optional icon, title, description and action.
+ * @since v1.0.1
  *
  * Used when a list, table, or section has no content to display.
  *

--- a/src/components/flex.ts
+++ b/src/components/flex.ts
@@ -2,6 +2,7 @@ import { boolAttr, define } from '../core/dom';
 
 /**
  * @summary Flexbox container with attribute-driven layout.
+ * @since v1.0.1
  *
  * @attr {'row'|'column'|'row-reverse'|'column-reverse'} [direction='row'] - `flex-direction` value.
  * @attr {'nowrap'|'wrap'|'wrap-reverse'} [wrap='nowrap'] - `flex-wrap` value.

--- a/src/components/float-button.ts
+++ b/src/components/float-button.ts
@@ -3,6 +3,7 @@ import { iconSvg } from '../core/icons';
 
 /**
  * @summary Standalone floating action button.
+ * @since v1.0.1
  *
  * @attr {string} [icon='plus'] - Icon name rendered inside the button.
  * @attr {string} [label] - Accessible label. Falls back to the icon name.

--- a/src/components/form.ts
+++ b/src/components/form.ts
@@ -2,6 +2,7 @@ import { boolAttr, define, patchText, randId } from '../core/dom';
 
 /**
  * @summary Form wrapper that intercepts `submit` and re-fires it as `e-submit`.
+ * @since v1.0.1
  *
  * @attr {'inline'} [layout] - Set to `inline` to render fields on one line.
  *

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -2,6 +2,7 @@ import { define } from '../core/dom';
 
 /**
  * @summary CSS grid container with attribute-driven columns and gap.
+ * @since v1.0.1
  *
  * @attr {string} [cols='12'] - Number of equal columns or a raw `grid-template-columns` value.
  * @attr {string} [gap='0'] - `gap` value. Bare numbers are treated as pixels.

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -3,6 +3,7 @@ import { ICONS, iconSvg } from '../core/icons';
 
 /**
  * @summary Inline SVG icon resolved by name from the built-in icon set.
+ * @since v1.0.1
  *
  * @attr {string} name - Icon identifier (must exist in the `ICONS` registry).
  * @attr {number} [size=20] - Pixel size (width and height).

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -2,6 +2,7 @@ import { boolAttr, define, patchAttr, patchText } from '../core/dom';
 
 /**
  * @summary Image with fallback, native lazy-loading and optional caption.
+ * @since v1.0.1
  *
  * Renders a `<figure>` wrapping an `<img>` (and an optional
  * `<figcaption>`). When loading fails, the element swaps to the `fallback`

--- a/src/components/input-number.md
+++ b/src/components/input-number.md
@@ -13,20 +13,22 @@ of `<input type="number">`). Step buttons support press-and-hold to repeat.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Current numeric value as a string. |
-| `min` | `string` | — | Lower bound (inclusive). |
-| `max` | `string` | — | Upper bound (inclusive). |
-| `step` | `string` | `'1'` | Step size for the buttons and native input. |
-| `aria-label` | — | — |  |
-| `default-value` | `string` | — | Initial value used by `formResetCallback`. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default | Description                                                        |
+| ------------------ | --------- | ------- | ------------------------------------------------------------------ |
+| `value`            | `string`  | —       | Current numeric value as a string.                                 |
+| `min`              | `string`  | —       | Lower bound (inclusive).                                           |
+| `max`              | `string`  | —       | Upper bound (inclusive).                                           |
+| `step`             | `string`  | `'1'`   | Step size for the buttons and native input.                        |
+| `aria-label`       | —         | —       |                                                                    |
+| `required`         | `boolean` | —       | Requires a numeric value.                                          |
+| `required-message` | `string`  | —       | Overrides the native message reported for an empty required value. |
+| `default-value`    | `string`  | —       | Initial value used by `formResetCallback`.                         |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.            |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                                                |
+| ---------- | ------------------------------ | ---------------------------------------------------------- |
 | `e-change` | `CustomEvent<{value: number}>` | Fired when the value changes via buttons or native commit. |
 
 ## Slots
@@ -35,6 +37,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/input-number.ts
+++ b/src/components/input-number.ts
@@ -4,6 +4,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Numeric input with increment/decrement buttons.
+ * @since v1.0.1
  *
  * Form-associated: the value is submitted as a string (matching the behaviour
  * of `<input type="number">`). Step buttons support press-and-hold to repeat.
@@ -14,6 +15,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [min] - Lower bound (inclusive).
  * @attr {string} [max] - Upper bound (inclusive).
  * @attr {string} [step='1'] - Step size for the buttons and native input.
+ * @attr {boolean} [required] - Requires a numeric value.
+ * @attr {string} [required-message] - Overrides the native message reported for an empty required value.
  *
  * @fires {CustomEvent<{value: number}>} e-change - Fired when the value changes via buttons or native commit.
  *
@@ -21,7 +24,15 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-input-number value="3" min="0" max="10" step="1"></e-input-number>
  */
 export class EInputNumber extends BaseFormControl<string> {
-  static observedAttributes = ['value', 'min', 'max', 'step', 'aria-label'];
+  static observedAttributes = [
+    'value',
+    'min',
+    'max',
+    'step',
+    'aria-label',
+    'required',
+    'required-message',
+  ];
 
   private _wired = false;
   private _input: HTMLInputElement | null = null;
@@ -48,6 +59,7 @@ export class EInputNumber extends BaseFormControl<string> {
     this.addEventListener('mouseleave', this._stopHold);
     this.addEventListener('touchend', this._stopHold);
     this.addEventListener('touchcancel', this._stopHold);
+    this._input?.addEventListener('input', this._onInput);
     this._input?.addEventListener('change', this._onInputChange);
     addCleanup(this, () => {
       this.removeEventListener('click', this._onClick);
@@ -56,6 +68,7 @@ export class EInputNumber extends BaseFormControl<string> {
       this.removeEventListener('mouseleave', this._stopHold);
       this.removeEventListener('touchend', this._stopHold);
       this.removeEventListener('touchcancel', this._stopHold);
+      this._input?.removeEventListener('input', this._onInput);
       this._input?.removeEventListener('change', this._onInputChange);
     });
   }
@@ -70,17 +83,27 @@ export class EInputNumber extends BaseFormControl<string> {
     if (name === 'value') {
       const next = v ?? '';
       this._input.value = next;
-      this._value = next;
-      this.internals.setFormValue(next);
+      this._value = this._input.value;
+      this.internals.setFormValue(this._value);
+      this._syncValidity();
     }
     if (name === 'min') {
       this._setFiniteInputAttr('min', v);
+      this._syncValidity();
     }
     if (name === 'max') {
       this._setFiniteInputAttr('max', v);
+      this._syncValidity();
     }
-    if (name === 'step') this._input.step = this._validStep(v);
+    if (name === 'step') {
+      this._input.step = this._validStep(v);
+      this._syncValidity();
+    }
     if (name === 'aria-label') patchAttr(this._input, 'aria-label', v);
+    if (name === 'required' || name === 'required-message') {
+      this._input.required = this.hasAttribute('required');
+      this._syncValidity();
+    }
   }
 
   override get value(): string {
@@ -111,8 +134,10 @@ export class EInputNumber extends BaseFormControl<string> {
     this._input.step = this._validStep(this.getAttribute('step'));
     this._setFiniteInputAttr('min', min);
     this._setFiniteInputAttr('max', max);
-    this._value = initial;
-    this.internals.setFormValue(initial);
+    this._input.required = this.hasAttribute('required');
+    this._value = this._input.value;
+    this.internals.setFormValue(this._value);
+    this._syncValidity();
   }
 
   private _step(direction: number): void {
@@ -122,6 +147,7 @@ export class EInputNumber extends BaseFormControl<string> {
     const next = this._input.value;
     this._value = next;
     this.internals.setFormValue(next);
+    this._syncValidity();
     this.setAttribute('value', next);
     this.dispatchEvent(
       new CustomEvent('e-change', {
@@ -174,6 +200,7 @@ export class EInputNumber extends BaseFormControl<string> {
     const value = this._input.value;
     this._value = value;
     this.internals.setFormValue(value);
+    this._syncValidity();
     this.setAttribute('value', value);
     this.dispatchEvent(
       new CustomEvent('e-change', {
@@ -182,6 +209,26 @@ export class EInputNumber extends BaseFormControl<string> {
       }),
     );
   };
+
+  private _onInput = (): void => {
+    if (!this._input) return;
+    this._value = this._input.value;
+    this.internals.setFormValue(this._value);
+    this._syncValidity();
+  };
+
+  private _syncValidity(): void {
+    if (!this._input) return;
+    if (this._input.validity.valueMissing) {
+      const message = this.getAttribute('required-message');
+      if (message) {
+        this.internals.setValidity({ valueMissing: true }, message, this._input);
+        this._input.setAttribute('aria-invalid', 'true');
+        return;
+      }
+    }
+    this.mirrorNativeValidity(this._input);
+  }
 }
 
 define('e-input-number', EInputNumber);

--- a/src/components/input.md
+++ b/src/components/input.md
@@ -12,27 +12,34 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Current value. Reflected via the `value` property. |
-| `error` | `boolean` | — | Marks the input as invalid. Sets `aria-invalid="true"` and a custom `ElementInternals` validity error so `form.checkValidity()` returns `false`. |
-| `error-message` | `string` | — | Message reported to `ElementInternals.setValidity` when `error` is set. Defaults to "Invalid value.". |
-| `disabled` | `boolean` | — | Disables interaction. |
-| `readonly` | `boolean` | — | Renders as a non-editable read-only input. Still submitted with the form. |
-| `aria-label` | — | — |  |
-| `placeholder` | `string` | — | Native placeholder text. |
-| `label` | `string` | — | Label rendered above the input. |
-| `hint` | `string` | — | Helper text rendered below the input. |
-| `type` | `string` | `'text'` | Native input type. |
-| `required` | `boolean` | — | Requires a non-empty value for form validation. |
-| `default-value` | `string` | — | Initial value used when `value` is not set. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default  | Description                                                                                                                                      |
+| ------------------ | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `value`            | `string`  | —        | Current value. Reflected via the `value` property.                                                                                               |
+| `error`            | `boolean` | —        | Marks the input as invalid. Sets `aria-invalid="true"` and a custom `ElementInternals` validity error so `form.checkValidity()` returns `false`. |
+| `error-message`    | `string`  | —        | Message reported to `ElementInternals.setValidity` when `error` is set. Defaults to "Invalid value.".                                            |
+| `disabled`         | `boolean` | —        | Disables interaction.                                                                                                                            |
+| `readonly`         | `boolean` | —        | Renders as a non-editable read-only input. Still submitted with the form.                                                                        |
+| `aria-label`       | —         | —        |                                                                                                                                                  |
+| `placeholder`      | `string`  | —        | Native placeholder text.                                                                                                                         |
+| `label`            | `string`  | —        | Label rendered above the input.                                                                                                                  |
+| `hint`             | `string`  | —        | Helper text rendered below the input.                                                                                                            |
+| `type`             | `string`  | `'text'` | Native input type.                                                                                                                               |
+| `required`         | `boolean` | —        | Requires a non-empty value for form validation.                                                                                                  |
+| `required-message` | `string`  | —        | Overrides the native message reported when `required` is not satisfied.                                                                          |
+| `pattern`          | `string`  | —        | Regular expression the value must match.                                                                                                         |
+| `minlength`        | `number`  | —        | Minimum text length.                                                                                                                             |
+| `maxlength`        | `number`  | —        | Maximum text length.                                                                                                                             |
+| `min`              | `string`  | —        | Minimum value for numeric and date-like input types.                                                                                             |
+| `max`              | `string`  | —        | Maximum value for numeric and date-like input types.                                                                                             |
+| `step`             | `string`  | —        | Step interval for numeric and date-like input types.                                                                                             |
+| `default-value`    | `string`  | —        | Initial value used when `value` is not set.                                                                                                      |
+| `name`             | `string`  | —        | Form field name. Required to participate in `FormData`.                                                                                          |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `e-input` | `CustomEvent<{value: string}>` | Fired on every keystroke. |
+| Event      | Detail                         | Description                   |
+| ---------- | ------------------------------ | ----------------------------- |
+| `e-input`  | `CustomEvent<{value: string}>` | Fired on every keystroke.     |
 | `e-change` | `CustomEvent<{value: string}>` | Fired on commit (blur/Enter). |
 
 ## Slots
@@ -41,6 +48,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/input.ts
+++ b/src/components/input.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Single-line text input with label, hint and error states.
+ * @since v1.0.1
  *
  * Form-associated: participates in `<form>` submission and FormData.
  *
@@ -18,6 +19,13 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {boolean} [disabled] - Disables interaction.
  * @attr {boolean} [readonly] - Renders as a non-editable read-only input. Still submitted with the form.
  * @attr {boolean} [required] - Requires a non-empty value for form validation.
+ * @attr {string} [required-message] - Overrides the native message reported when `required` is not satisfied.
+ * @attr {string} [pattern] - Regular expression the value must match.
+ * @attr {number} [minlength] - Minimum text length.
+ * @attr {number} [maxlength] - Maximum text length.
+ * @attr {string} [min] - Minimum value for numeric and date-like input types.
+ * @attr {string} [max] - Maximum value for numeric and date-like input types.
+ * @attr {string} [step] - Step interval for numeric and date-like input types.
  *
  * @fires {CustomEvent<{value: string}>} e-input - Fired on every keystroke.
  * @fires {CustomEvent<{value: string}>} e-change - Fired on commit (blur/Enter).
@@ -38,6 +46,13 @@ export class EInput extends BaseFormControl {
     'hint',
     'type',
     'required',
+    'required-message',
+    'pattern',
+    'minlength',
+    'maxlength',
+    'min',
+    'max',
+    'step',
   ];
 
   private _wired = false;
@@ -70,8 +85,11 @@ export class EInput extends BaseFormControl {
     this._input = this.querySelector('input');
     this._label = this.querySelector('label.ink-label');
     this._hint = this.querySelector('.ink-hint');
-    this._value = value;
-    this.internals.setFormValue(value);
+    for (const name of ['pattern', 'minlength', 'maxlength', 'min', 'max', 'step']) {
+      this._syncNativeConstraint(name, this.getAttribute(name));
+    }
+    this._value = this._input!.value;
+    this.internals.setFormValue(this._value);
     this._syncValidity();
     this._input!.addEventListener('input', (e) => {
       const v = (e.target as HTMLInputElement).value;
@@ -84,6 +102,7 @@ export class EInput extends BaseFormControl {
       const v = (e.target as HTMLInputElement).value;
       this._value = v;
       this.internals.setFormValue(v);
+      this._syncValidity();
       this.dispatchEvent(new CustomEvent('e-change', { detail: { value: v }, bubbles: true }));
     });
   }
@@ -92,15 +111,11 @@ export class EInput extends BaseFormControl {
     if (!this._input) return;
     if (name === 'value') {
       if (this._input.value !== (v ?? '')) this._input.value = v ?? '';
-      this._value = v ?? '';
+      this._value = this._input.value;
       this.internals.setFormValue(this._value);
-    }
-    if (name === 'error' || name === 'error-message') {
-      const on = boolAttr(this, 'error');
-      if (on) this._input.setAttribute('aria-invalid', 'true');
-      else this._input.removeAttribute('aria-invalid');
       this._syncValidity();
     }
+    if (name === 'error' || name === 'error-message') this._syncValidity();
     if (name === 'disabled') {
       this._input.disabled = boolAttr(this, 'disabled') || this._formDisabled;
     }
@@ -114,9 +129,18 @@ export class EInput extends BaseFormControl {
     if (name === 'placeholder') {
       this._input.placeholder = v ?? '';
     }
-    if (name === 'type') this._input.type = v || 'text';
-    if (name === 'required') {
+    if (name === 'type') {
+      this._input.type = v || 'text';
+      this._value = this._input.value;
+      this.internals.setFormValue(this._value);
+      this._syncValidity();
+    }
+    if (name === 'required' || name === 'required-message') {
       this._input.required = boolAttr(this, 'required');
+      this._syncValidity();
+    }
+    if (['pattern', 'minlength', 'maxlength', 'min', 'max', 'step'].includes(name)) {
+      this._syncNativeConstraint(name, v);
       this._syncValidity();
     }
     if (name === 'label') this._syncLabel(v ?? '');
@@ -127,8 +151,13 @@ export class EInput extends BaseFormControl {
     return this._input?.value ?? this._value;
   }
   override set value(v: string) {
-    this._value = v ?? '';
-    if (this._input) this._input.value = this._value;
+    const next = v ?? '';
+    if (this._input) {
+      this._input.value = next;
+      this._value = this._input.value;
+    } else {
+      this._value = next;
+    }
     this.internals.setFormValue(this._value);
     this._syncValidity();
   }
@@ -147,18 +176,26 @@ export class EInput extends BaseFormControl {
   }
 
   private _syncValidity(): void {
-    if (boolAttr(this, 'error')) {
-      const msg = this.getAttribute('error-message') ?? 'Invalid value.';
-      this.internals.setValidity({ customError: true }, msg, this._input ?? undefined);
-    } else if (boolAttr(this, 'required') && !this.value) {
-      this.internals.setValidity(
-        { valueMissing: true },
-        'Please fill out this field.',
-        this._input ?? undefined,
-      );
-    } else {
-      this.internals.setValidity({});
+    if (!this._input) return;
+    this._input.required = boolAttr(this, 'required');
+    const customMessage = boolAttr(this, 'error')
+      ? (this.getAttribute('error-message') ?? 'Invalid value.')
+      : undefined;
+    if (!customMessage && this._input.validity.valueMissing) {
+      const message = this.getAttribute('required-message');
+      if (message) {
+        this.internals.setValidity({ valueMissing: true }, message, this._input);
+        this._input.setAttribute('aria-invalid', 'true');
+        return;
+      }
     }
+    this.mirrorNativeValidity(this._input, customMessage);
+  }
+
+  private _syncNativeConstraint(name: string, value: string | null): void {
+    if (!this._input) return;
+    if (value == null) this._input.removeAttribute(name);
+    else this._input.setAttribute(name, value);
   }
 
   private _syncLabel(value: string): void {

--- a/src/components/kaleido.ts
+++ b/src/components/kaleido.ts
@@ -65,6 +65,7 @@ function paintDither(canvas: HTMLCanvasElement, hex: string, size: number, cell:
 
 /**
  * @summary Color palette swatches with Bayer-dithered preview canvases.
+ * @since v1.0.1
  *
  * @attr {number} [cell=3] - Pixel size of a single dither cell. Smaller values produce a finer pattern.
  *

--- a/src/components/layout.ts
+++ b/src/components/layout.ts
@@ -2,6 +2,7 @@ import { boolAttr, captureWrap, clampedNumAttr, define } from '../core/dom';
 
 /**
  * @summary Page-level layout container that arranges header, sider, content and footer children.
+ * @since v1.0.1
  *
  * @attr {boolean} [has-sider] - Switches the inner direction so a sider can sit beside the content.
  *

--- a/src/components/link.ts
+++ b/src/components/link.ts
@@ -2,6 +2,7 @@ import { captureWrap, define, patchAttr } from '../core/dom';
 
 /**
  * @summary Inline anchor styled with the design-system underline.
+ * @since v1.0.1
  *
  * Children are used as the link text.
  *

--- a/src/components/list.ts
+++ b/src/components/list.ts
@@ -2,6 +2,7 @@ import { boolAttr, define, patchBoolAttr, patchText } from '../core/dom';
 
 /**
  * @summary Structured list with header / footer slots and `<e-list-item>` rows.
+ * @since v1.0.1
  *
  * Different from a native `<ul>` because items are slot-driven (title,
  * description, leading, trailing) and the container owns the framing.

--- a/src/components/masonry.ts
+++ b/src/components/masonry.ts
@@ -2,6 +2,7 @@ import { define, intAttr, numAttr } from '../core/dom';
 
 /**
  * @summary CSS-columns based masonry layout for cards of varying height.
+ * @since v1.0.1
  *
  * CSS selectors apply the configured gap to current and dynamically inserted
  * children without observers or JavaScript layout reads.

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -29,6 +29,7 @@ interface RenderedItem {
 
 /**
  * @summary Hierarchical navigation menu rendered from `<e-menu-item>` children.
+ * @since v1.0.1
  *
  * @attr {'horizontal'|'vertical'} [mode='vertical'] - Menu orientation. Reactive.
  * @attr {string} [value] - Currently active item value. Reactive.

--- a/src/components/pagination.ts
+++ b/src/components/pagination.ts
@@ -8,6 +8,7 @@ interface PageCell {
 
 /**
  * @summary Page navigator with previous/next buttons and ellipsized page numbers.
+ * @since v1.0.1
  *
  * @attr {number} [current=1] - Current page (1-indexed). Reflected on user navigation.
  * @attr {number} [total=1] - Total number of pages.

--- a/src/components/popover.ts
+++ b/src/components/popover.ts
@@ -133,6 +133,7 @@ class Popup {
 
 /**
  * @summary Click-triggered overlay panel anchored to its trigger.
+ * @since v1.1.0
  *
  * The counterpart to a tooltip for hardware that has no hover: capacitive
  * e-paper digitizers report contact, not proximity, so anything that would be

--- a/src/components/progress.ts
+++ b/src/components/progress.ts
@@ -2,6 +2,7 @@ import { define, intAttr, numAttr, patchAttr, patchBoolAttr, patchText } from '.
 
 /**
  * @summary Static progress indicator (linear bar or discrete steps).
+ * @since v1.0.1
  *
  * No animation: the bar updates as a single dirty rectangle which the EPDC
  * can resolve with a partial waveform.

--- a/src/components/qrcode.ts
+++ b/src/components/qrcode.ts
@@ -478,6 +478,7 @@ function qrToSvg(qr: QrCode, scale: number, border: number): string {
 
 /**
  * @summary QR code rendered as inline SVG. Zero runtime dependencies.
+ * @since v1.0.1
  *
  * Encodes text in byte mode (UTF-8) and selects the smallest version that
  * fits at the given error-correction level. The output is pure SVG with two

--- a/src/components/radio-group.md
+++ b/src/components/radio-group.md
@@ -13,16 +13,18 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Currently selected option value. |
-| `layout` | `'horizontal'\|'vertical'` | `'horizontal'` | Stacking direction. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type                       | Default        | Description                                             |
+| ------------------ | -------------------------- | -------------- | ------------------------------------------------------- |
+| `value`            | `string`                   | —              | Currently selected option value.                        |
+| `layout`           | `'horizontal'\|'vertical'` | `'horizontal'` | Stacking direction.                                     |
+| `required`         | `boolean`                  | —              | Requires one selected option.                           |
+| `required-message` | `string`                   | —              | Message reported when no required option is selected.   |
+| `name`             | `string`                   | —              | Form field name. Required to participate in `FormData`. |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                       |
+| ---------- | ------------------------------ | --------------------------------- |
 | `e-change` | `CustomEvent<{value: string}>` | Fired when the selection changes. |
 
 ## Slots
@@ -31,6 +33,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/radio-group.ts
+++ b/src/components/radio-group.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Group of radio options sharing a single value.
+ * @since v1.0.1
  *
  * Reads options from `<e-radio>` children at connect time.
  * Form-associated: participates in `<form>` submission and FormData.
@@ -10,6 +11,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [value] - Currently selected option value.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {'horizontal'|'vertical'} [layout='horizontal'] - Stacking direction.
+ * @attr {boolean} [required] - Requires one selected option.
+ * @attr {string} [required-message] - Message reported when no required option is selected.
  *
  * @fires {CustomEvent<{value: string}>} e-change - Fired when the selection changes.
  *
@@ -20,7 +23,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-radio-group>
  */
 export class ERadioGroup extends BaseFormControl {
-  static observedAttributes = ['value', 'layout'];
+  static observedAttributes = ['value', 'layout', 'required', 'required-message'];
 
   private _wired = false;
 
@@ -48,6 +51,7 @@ export class ERadioGroup extends BaseFormControl {
     </div>`;
     this._value = value;
     this.internals.setFormValue(value);
+    this._syncValidity();
     this.addEventListener('change', (e) => {
       const target = e.target as HTMLInputElement;
       if (target.matches('input[type="radio"]')) {
@@ -68,6 +72,10 @@ export class ERadioGroup extends BaseFormControl {
       if (group) group.classList.toggle('ink-radio-group--vertical', v === 'vertical');
       return;
     }
+    if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
+      return;
+    }
     if (name !== 'value') return;
     const newValue = v ?? '';
     if (newValue === this._value) return;
@@ -76,6 +84,7 @@ export class ERadioGroup extends BaseFormControl {
     this.querySelectorAll<HTMLInputElement>('input[type="radio"]').forEach((r) => {
       r.checked = r.value === newValue;
     });
+    this._syncValidity();
   }
 
   override get value(): string {
@@ -94,6 +103,12 @@ export class ERadioGroup extends BaseFormControl {
 
   override formResetCallback(): void {
     this.value = this.getAttribute('default-value') ?? '';
+  }
+
+  private _syncValidity(): void {
+    const group = this.querySelector<HTMLElement>('[role="radiogroup"]') ?? undefined;
+    group?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(!!this.value, group, 'Please select an option.');
   }
 }
 define('e-radio-group', ERadioGroup);

--- a/src/components/result.ts
+++ b/src/components/result.ts
@@ -16,6 +16,7 @@ const isStatus = (s: string | null): s is Status =>
 
 /**
  * @summary Status page block (success / error / 404 / info / warning).
+ * @since v1.0.1
  *
  * Use as the body of a confirmation page or an error fallback. Composes an
  * icon, a large title, optional description and a slotted action area.

--- a/src/components/ribbon.ts
+++ b/src/components/ribbon.ts
@@ -2,6 +2,7 @@ import { captureWrap, define, patchText } from '../core/dom';
 
 /**
  * @summary Decorative ribbon tag overlaid on a child element.
+ * @since v1.0.1
  *
  * Children are wrapped and decorated with the ribbon tag.
  *

--- a/src/components/segmented.ts
+++ b/src/components/segmented.ts
@@ -2,6 +2,7 @@ import { addCleanup, define, patchAttr, runCleanups } from '../core/dom';
 
 /**
  * @summary Single-select toggle row built from `<e-segment>` children.
+ * @since v1.0.1
  *
  * @attr {string} [value] - Currently selected segment value. Reactive.
  *

--- a/src/components/select.md
+++ b/src/components/select.md
@@ -12,16 +12,18 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Currently selected option value. |
-| `placeholder` | `string` | `'Select…'` | Trigger placeholder when no value is set. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default     | Description                                             |
+| ------------------ | --------- | ----------- | ------------------------------------------------------- |
+| `value`            | `string`  | —           | Currently selected option value.                        |
+| `placeholder`      | `string`  | `'Select…'` | Trigger placeholder when no value is set.               |
+| `required`         | `boolean` | —           | Requires a selected option.                             |
+| `required-message` | `string`  | —           | Message reported when no required option is selected.   |
+| `name`             | `string`  | —           | Form field name. Required to participate in `FormData`. |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                                   |
+| ---------- | ------------------------------ | --------------------------------------------- |
 | `e-change` | `CustomEvent<{value: string}>` | Fired when the user picks a different option. |
 
 ## Slots
@@ -30,6 +32,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/select.ts
+++ b/src/components/select.ts
@@ -4,12 +4,15 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Single-select dropdown built from `<e-option>` children.
+ * @since v1.0.1
  *
  * Form-associated: participates in `<form>` submission and FormData.
  *
  * @attr {string} [value] - Currently selected option value.
  * @attr {string} [placeholder='Select…'] - Trigger placeholder when no value is set.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
+ * @attr {boolean} [required] - Requires a selected option.
+ * @attr {string} [required-message] - Message reported when no required option is selected.
  *
  * @fires {CustomEvent<{value: string}>} e-change - Fired when the user picks a different option.
  *
@@ -20,7 +23,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-select>
  */
 export class ESelect extends BaseFormControl {
-  static observedAttributes = ['value', 'placeholder'];
+  static observedAttributes = ['value', 'placeholder', 'required', 'required-message'];
 
   private _wired = false;
   private _trigger: HTMLElement | null = null;
@@ -76,6 +79,7 @@ export class ESelect extends BaseFormControl {
       for (const opt of this._optEls) {
         opt.tabIndex = opt.getAttribute('aria-selected') === 'true' ? 0 : -1;
       }
+      this._syncValidity();
     }
 
     this._trigger!.addEventListener('click', this._onTriggerClick);
@@ -168,6 +172,10 @@ export class ESelect extends BaseFormControl {
       }
       return;
     }
+    if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
+      return;
+    }
     if (name !== 'value') return;
     const newValue = v ?? '';
     if (newValue === this._value) return;
@@ -194,6 +202,7 @@ export class ESelect extends BaseFormControl {
       const opt = this._opts.find((o) => o.value === newValue);
       patchText(this._triggerLabel, opt ? opt.label : this._placeholder);
     }
+    this._syncValidity();
   }
 
   override get value(): string {
@@ -212,6 +221,15 @@ export class ESelect extends BaseFormControl {
 
   override formResetCallback(): void {
     this.value = this.getAttribute('default-value') ?? '';
+  }
+
+  private _syncValidity(): void {
+    this._trigger?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(
+      !!this._value,
+      this._trigger ?? undefined,
+      'Please select an option.',
+    );
   }
 }
 define('e-select', ESelect);

--- a/src/components/skeleton.ts
+++ b/src/components/skeleton.ts
@@ -2,6 +2,7 @@ import { define, intAttr, patchAttr } from '../core/dom';
 
 /**
  * @summary Static loading placeholder block.
+ * @since v1.0.1
  *
  * Pure outline — no shimmer, no animation. Use to reserve space for content
  * that is loading. On e-paper this avoids triggering a full GC16 refresh

--- a/src/components/space.ts
+++ b/src/components/space.ts
@@ -2,6 +2,7 @@ import { boolAttr, define, numAttr } from '../core/dom';
 
 /**
  * @summary Inline-flex container that distributes children with a uniform gap.
+ * @since v1.0.1
  *
  * @attr {string} [size='8'] - Pixel gap between children.
  * @attr {'horizontal'|'vertical'} [direction='horizontal'] - Stacking direction.

--- a/src/components/splitter.ts
+++ b/src/components/splitter.ts
@@ -2,6 +2,7 @@ import { addCleanup, clampedNumAttr, define, onGlobal, patchAttr, runCleanups } 
 
 /**
  * @summary Two-pane resizable splitter with mouse and keyboard support.
+ * @since v1.0.1
  *
  * @attr {'horizontal'|'vertical'} [orientation='horizontal'] - Layout direction. Horizontal places panes side by side; vertical stacks them.
  * @attr {number} [initial=50] - Initial size of pane `a` as a percentage.

--- a/src/components/statistic.ts
+++ b/src/components/statistic.ts
@@ -2,6 +2,7 @@ import { clampedNumAttr, define, patchAttr, patchText } from '../core/dom';
 
 /**
  * @summary KPI block with a large numeric value, label and optional trend arrow.
+ * @since v1.0.1
  *
  * Use to present a single metric (e.g. revenue, users, score) with an
  * optional secondary delta. Numeric formatting is locale-independent and

--- a/src/components/steps.ts
+++ b/src/components/steps.ts
@@ -3,6 +3,7 @@ import { iconSvg } from '../core/icons';
 
 /**
  * @summary Numbered or check-marked step list rendered from `<e-step>` children.
+ * @since v1.0.1
  *
  * @attr {number} [current=0] - Index of the active step (0-based). Reactive.
  * @attr {'horizontal'|'vertical'} [orientation='horizontal'] - Layout direction. Reactive.

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -54,6 +54,7 @@ const parseJson = <T>(s: string | null, fallback: T): T => {
 
 /**
  * @summary Data grid with header, optional sort and row-selection.
+ * @since v1.0.1
  *
  * Sort is **static**: clicking the header toggles `none → asc → desc → none`
  * and emits `e-sort`. The component never re-orders rows itself — owners

--- a/src/components/tabs.ts
+++ b/src/components/tabs.ts
@@ -4,6 +4,7 @@ import './badge';
 
 /**
  * @summary Tab strip with persistent panels rendered from `<e-tab>` children.
+ * @since v1.0.1
  *
  * All panels are built once at connect time and toggled with `hidden` on
  * tab switch — nested Custom Elements (form controls etc.) keep their state.

--- a/src/components/tag.ts
+++ b/src/components/tag.ts
@@ -2,6 +2,7 @@ import { addCleanup, boolAttr, captureWrap, define, patchBoolAttr, runCleanups }
 
 /**
  * @summary Small inline label, optionally removable.
+ * @since v1.0.1
  *
  * Children are used as the tag text. Distinct from `<e-badge>` (purely
  * decorative) because a tag can be dismissed by the user via a close button.

--- a/src/components/text.ts
+++ b/src/components/text.ts
@@ -2,6 +2,7 @@ import { captureWrap, define, patchClassModifier } from '../core/dom';
 
 /**
  * @summary Typography wrapper with semantic tag and visual kind selectors.
+ * @since v1.0.1
  *
  * Children are used as the text content.
  *

--- a/src/components/textarea.md
+++ b/src/components/textarea.md
@@ -12,23 +12,26 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Current value. |
-| `error` | `boolean` | — | Marks the textarea as invalid. Sets `aria-invalid="true"` and a custom `ElementInternals` validity error so `form.checkValidity()` returns `false`. |
-| `error-message` | `string` | — | Message reported to `ElementInternals.setValidity` when `error` is set. Defaults to "Invalid value.". |
-| `disabled` | `boolean` | — | Disables interaction. |
-| `readonly` | `boolean` | — | Renders as a non-editable read-only textarea. Still submitted with the form. |
-| `aria-label` | — | — |  |
-| `placeholder` | `string` | — | Native placeholder text. |
-| `required` | `boolean` | — | Requires a non-empty value for form validation. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default | Description                                                                                                                                         |
+| ------------------ | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`            | `string`  | —       | Current value.                                                                                                                                      |
+| `error`            | `boolean` | —       | Marks the textarea as invalid. Sets `aria-invalid="true"` and a custom `ElementInternals` validity error so `form.checkValidity()` returns `false`. |
+| `error-message`    | `string`  | —       | Message reported to `ElementInternals.setValidity` when `error` is set. Defaults to "Invalid value.".                                               |
+| `disabled`         | `boolean` | —       | Disables interaction.                                                                                                                               |
+| `readonly`         | `boolean` | —       | Renders as a non-editable read-only textarea. Still submitted with the form.                                                                        |
+| `aria-label`       | —         | —       |                                                                                                                                                     |
+| `placeholder`      | `string`  | —       | Native placeholder text.                                                                                                                            |
+| `required`         | `boolean` | —       | Requires a non-empty value for form validation.                                                                                                     |
+| `required-message` | `string`  | —       | Overrides the native message reported when `required` is not satisfied.                                                                             |
+| `minlength`        | `number`  | —       | Minimum text length.                                                                                                                                |
+| `maxlength`        | `number`  | —       | Maximum text length.                                                                                                                                |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.                                                                                             |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `e-input` | `CustomEvent<{value: string}>` | Fired on every keystroke. |
+| Event      | Detail                         | Description                     |
+| ---------- | ------------------------------ | ------------------------------- |
+| `e-input`  | `CustomEvent<{value: string}>` | Fired on every keystroke.       |
 | `e-change` | `CustomEvent<{value: string}>` | Fired on commit (blur / Enter). |
 
 ## Slots
@@ -37,6 +40,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/textarea.ts
+++ b/src/components/textarea.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Multi-line text input with error and disabled states.
+ * @since v1.0.1
  *
  * Form-associated: participates in `<form>` submission and FormData.
  *
@@ -14,6 +15,9 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {boolean} [disabled] - Disables interaction.
  * @attr {boolean} [readonly] - Renders as a non-editable read-only textarea. Still submitted with the form.
  * @attr {boolean} [required] - Requires a non-empty value for form validation.
+ * @attr {string} [required-message] - Overrides the native message reported when `required` is not satisfied.
+ * @attr {number} [minlength] - Minimum text length.
+ * @attr {number} [maxlength] - Maximum text length.
  *
  * @fires {CustomEvent<{value: string}>} e-input - Fired on every keystroke.
  * @fires {CustomEvent<{value: string}>} e-change - Fired on commit (blur / Enter).
@@ -31,6 +35,9 @@ export class ETextarea extends BaseFormControl {
     'aria-label',
     'placeholder',
     'required',
+    'required-message',
+    'minlength',
+    'maxlength',
   ];
 
   private _wired = false;
@@ -51,6 +58,9 @@ export class ETextarea extends BaseFormControl {
       ${ariaLabel ? `aria-label="${esc(ariaLabel)}"` : ''}
       ${error ? 'aria-invalid="true"' : ''} ${disabled ? 'disabled' : ''} ${readonly ? 'readonly' : ''} ${required ? 'required' : ''}>${esc(value)}</textarea>`;
     this._ta = this.querySelector('textarea');
+    for (const name of ['minlength', 'maxlength']) {
+      this._syncNativeConstraint(name, this.getAttribute(name));
+    }
     this._value = value;
     this.internals.setFormValue(value);
     this._syncValidity();
@@ -65,6 +75,7 @@ export class ETextarea extends BaseFormControl {
       const v = (e.target as HTMLTextAreaElement).value;
       this._value = v;
       this.internals.setFormValue(v);
+      this._syncValidity();
       this.dispatchEvent(new CustomEvent('e-change', { detail: { value: v }, bubbles: true }));
     });
   }
@@ -75,22 +86,22 @@ export class ETextarea extends BaseFormControl {
       if (this._ta.value !== (v ?? '')) this._ta.value = v ?? '';
       this._value = v ?? '';
       this.internals.setFormValue(this._value);
+      this._syncValidity();
     }
     if (name === 'aria-label') {
       if (v) this._ta.setAttribute('aria-label', v);
       else this._ta.removeAttribute('aria-label');
     }
-    if (name === 'error' || name === 'error-message') {
-      const on = boolAttr(this, 'error');
-      if (on) this._ta.setAttribute('aria-invalid', 'true');
-      else this._ta.removeAttribute('aria-invalid');
-      this._syncValidity();
-    }
+    if (name === 'error' || name === 'error-message') this._syncValidity();
     if (name === 'disabled') this._ta.disabled = boolAttr(this, 'disabled') || this._formDisabled;
     if (name === 'readonly') this._ta.readOnly = boolAttr(this, 'readonly');
     if (name === 'placeholder') this._ta.placeholder = v ?? '';
-    if (name === 'required') {
+    if (name === 'required' || name === 'required-message') {
       this._ta.required = boolAttr(this, 'required');
+      this._syncValidity();
+    }
+    if (name === 'minlength' || name === 'maxlength') {
+      this._syncNativeConstraint(name, v);
       this._syncValidity();
     }
   }
@@ -119,18 +130,26 @@ export class ETextarea extends BaseFormControl {
   }
 
   private _syncValidity(): void {
-    if (boolAttr(this, 'error')) {
-      const msg = this.getAttribute('error-message') ?? 'Invalid value.';
-      this.internals.setValidity({ customError: true }, msg, this._ta ?? undefined);
-    } else if (boolAttr(this, 'required') && !this.value) {
-      this.internals.setValidity(
-        { valueMissing: true },
-        'Please fill out this field.',
-        this._ta ?? undefined,
-      );
-    } else {
-      this.internals.setValidity({});
+    if (!this._ta) return;
+    this._ta.required = boolAttr(this, 'required');
+    const customMessage = boolAttr(this, 'error')
+      ? (this.getAttribute('error-message') ?? 'Invalid value.')
+      : undefined;
+    if (!customMessage && this._ta.validity.valueMissing) {
+      const message = this.getAttribute('required-message');
+      if (message) {
+        this.internals.setValidity({ valueMissing: true }, message, this._ta);
+        this._ta.setAttribute('aria-invalid', 'true');
+        return;
+      }
     }
+    this.mirrorNativeValidity(this._ta, customMessage);
+  }
+
+  private _syncNativeConstraint(name: string, value: string | null): void {
+    if (!this._ta) return;
+    if (value == null) this._ta.removeAttribute(name);
+    else this._ta.setAttribute(name, value);
   }
 
   protected override formDisabledChanged(): void {

--- a/src/components/time-picker.md
+++ b/src/components/time-picker.md
@@ -12,15 +12,17 @@ Form-associated: participates in `<form>` submission and FormData.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | `'00:00'` | Current time in `HH:MM` format. Wraps around the 24-hour and 60-minute boundaries. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default   | Description                                                                        |
+| ------------------ | --------- | --------- | ---------------------------------------------------------------------------------- |
+| `value`            | `string`  | `'00:00'` | Current time in `HH:MM` format. Wraps around the 24-hour and 60-minute boundaries. |
+| `required`         | `boolean` | —         | Requires a valid time value. The default `00:00` satisfies this constraint.        |
+| `required-message` | `string`  | —         | Message reported when no required time is selected.                                |
+| `name`             | `string`  | —         | Form field name. Required to participate in `FormData`.                            |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                                               |
+| ---------- | ------------------------------ | --------------------------------------------------------- |
 | `e-change` | `CustomEvent<{value: string}>` | Fired when the user changes the time. `value` is `HH:MM`. |
 
 ## Slots
@@ -29,6 +31,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/time-picker.ts
+++ b/src/components/time-picker.ts
@@ -5,11 +5,14 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Hour/minute picker with stepper buttons.
+ * @since v1.0.1
  *
  * Form-associated: participates in `<form>` submission and FormData.
  *
  * @attr {string} [value='00:00'] - Current time in `HH:MM` format. Wraps around the 24-hour and 60-minute boundaries.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
+ * @attr {boolean} [required] - Requires a valid time value. The default `00:00` satisfies this constraint.
+ * @attr {string} [required-message] - Message reported when no required time is selected.
  *
  * @fires {CustomEvent<{value: string}>} e-change - Fired when the user changes the time. `value` is `HH:MM`.
  *
@@ -17,7 +20,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-time-picker value="09:30"></e-time-picker>
  */
 export class ETimePicker extends BaseFormControl {
-  static observedAttributes = ['value'];
+  static observedAttributes = ['value', 'required', 'required-message'];
 
   private _wired = false;
   private _hCell: HTMLElement | null = null;
@@ -30,6 +33,7 @@ export class ETimePicker extends BaseFormControl {
       this._value = initial;
       this.internals.setFormValue(initial);
       this._build();
+      this._syncValidity();
     }
 
     this.addEventListener('click', this._onClick);
@@ -43,6 +47,10 @@ export class ETimePicker extends BaseFormControl {
   }
 
   attributeChangedCallback(name: string, _old: string | null, v: string | null) {
+    if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
+      return;
+    }
     if (name !== 'value') return;
     const normalized = this._normalize(v);
     if (v != null && v !== normalized) {
@@ -52,6 +60,7 @@ export class ETimePicker extends BaseFormControl {
     this._value = normalized;
     this.internals.setFormValue(this._value);
     if (this._wired) this._applyValue(this._value);
+    this._syncValidity();
   }
 
   private _build(): void {
@@ -186,6 +195,12 @@ export class ETimePicker extends BaseFormControl {
   override formResetCallback(): void {
     const dflt = this.getAttribute('default-value') ?? '00:00';
     this.setAttribute('value', dflt);
+  }
+
+  private _syncValidity(): void {
+    const anchor = this._hCell ?? undefined;
+    anchor?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(!!this._value, anchor, 'Please select a time.');
   }
 }
 

--- a/src/components/timeline.ts
+++ b/src/components/timeline.ts
@@ -2,6 +2,7 @@ import { define } from '../core/dom';
 
 /**
  * @summary Vertical list of timestamped events with marker bullets.
+ * @since v1.0.1
  *
  * Reads its entries from child `<e-timeline-item>` elements at connect time.
  * Items are rendered as `<li>` rows with a marker, time label, title and

--- a/src/components/title.ts
+++ b/src/components/title.ts
@@ -2,6 +2,7 @@ import { define, numAttr } from '../core/dom';
 
 /**
  * @summary Heading element rendered as `<h1>`…`<h6>` based on `level`.
+ * @since v1.0.1
  *
  * Children are used as the heading text.
  *

--- a/src/components/toggle.md
+++ b/src/components/toggle.md
@@ -12,18 +12,20 @@ Form-associated: submits its `value` (defaults to `"on"`) when checked.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `checked` | `boolean` | — | Whether the switch is on. Reflected to the attribute on user input. |
-| `label` | `string` | — | Inline text label rendered next to the switch. |
-| `disabled` | `boolean` | — | Disables interaction. |
-| `value` | `string` | `'on'` | Submitted value when checked. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default | Description                                                         |
+| ------------------ | --------- | ------- | ------------------------------------------------------------------- |
+| `checked`          | `boolean` | —       | Whether the switch is on. Reflected to the attribute on user input. |
+| `label`            | `string`  | —       | Inline text label rendered next to the switch.                      |
+| `disabled`         | `boolean` | —       | Disables interaction.                                               |
+| `value`            | `string`  | `'on'`  | Submitted value when checked.                                       |
+| `required`         | `boolean` | —       | Requires the switch to be on.                                       |
+| `required-message` | `string`  | —       | Message reported when the required switch is off.                   |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.             |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                            | Description                           |
+| ---------- | --------------------------------- | ------------------------------------- |
 | `e-change` | `CustomEvent<{checked: boolean}>` | Fired when the checked state changes. |
 
 ## Slots
@@ -32,7 +34,7 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `checked` | `boolean` | no |  |
-| `value` | `string` | no |  |
+| Property  | Type      | Read-only | Description |
+| --------- | --------- | --------- | ----------- |
+| `checked` | `boolean` | no        |             |
+| `value`   | `string`  | no        |             |

--- a/src/components/toggle.ts
+++ b/src/components/toggle.ts
@@ -3,6 +3,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary On/off switch with an optional inline label and ON/OFF state pill.
+ * @since v1.0.1
  *
  * Form-associated: submits its `value` (defaults to `"on"`) when checked.
  *
@@ -11,6 +12,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [label] - Inline text label rendered next to the switch.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {string} [value='on'] - Submitted value when checked.
+ * @attr {boolean} [required] - Requires the switch to be on.
+ * @attr {string} [required-message] - Message reported when the required switch is off.
  *
  * @fires {CustomEvent<{checked: boolean}>} e-change - Fired when the checked state changes.
  *
@@ -18,7 +21,14 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-toggle checked label="Enable notifications"></e-toggle>
  */
 export class EToggle extends BaseFormControl {
-  static observedAttributes = ['checked', 'label', 'disabled', 'value'];
+  static observedAttributes = [
+    'checked',
+    'label',
+    'disabled',
+    'value',
+    'required',
+    'required-message',
+  ];
 
   private _wired = false;
   private _cb: HTMLInputElement | null = null;
@@ -28,6 +38,10 @@ export class EToggle extends BaseFormControl {
     const v = this.getAttribute('value') || 'on';
     const checked = !!this._cb?.checked;
     this.internals.setFormValue(checked ? v : null, checked ? 'checked' : 'unchecked');
+    if (this._cb) {
+      this._cb.required = boolAttr(this, 'required');
+      this.applyRequiredValidity(checked, this._cb, 'Please turn on this switch.');
+    }
   }
 
   connectedCallback() {
@@ -72,6 +86,7 @@ export class EToggle extends BaseFormControl {
     }
     if (name === 'disabled') this._cb.disabled = boolAttr(this, 'disabled') || this._formDisabled;
     if (name === 'value') this._syncFormValue();
+    if (name === 'required' || name === 'required-message') this._syncFormValue();
     if (name === 'label') {
       const text = this.getAttribute('label') || '';
       const label = this.querySelector('label.ink-toggle') as HTMLElement | null;

--- a/src/components/tree-select.md
+++ b/src/components/tree-select.md
@@ -12,20 +12,22 @@ Form-associated: submits the selected node's value.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | — | Currently selected node value. |
-| `data` | `string` | `'[]'` | JSON-encoded array of `{value, label, children?}` nodes. Canonical attribute, shared with `<e-cascader>`. |
-| `options` | `string` | `'[]'` | Alias for `data` for symmetry with `<e-cascader>`. When both are set, `data` wins. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
-| `default-expanded` | `string` | — | Comma-separated list of node values that are expanded on first render. |
+| Attribute          | Type      | Default | Description                                                                                               |
+| ------------------ | --------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `value`            | `string`  | —       | Currently selected node value.                                                                            |
+| `data`             | `string`  | `'[]'`  | JSON-encoded array of `{value, label, children?}` nodes. Canonical attribute, shared with `<e-cascader>`. |
+| `options`          | `string`  | `'[]'`  | Alias for `data` for symmetry with `<e-cascader>`. When both are set, `data` wins.                        |
+| `required`         | `boolean` | —       | Requires a selected tree node.                                                                            |
+| `required-message` | `string`  | —       | Message reported when no required node is selected.                                                       |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.                                                   |
+| `default-expanded` | `string`  | —       | Comma-separated list of node values that are expanded on first render.                                    |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `e-error` | `CustomEvent<{error: Error, source: 'data' \| 'options'}>` | Fired when the `data` or `options` attribute fails to parse as JSON. The internal tree falls back to `[]`. |
-| `e-change` | `CustomEvent<{value: string}>` | Fired when the user selects a node. `value` is the node's value. |
+| Event      | Detail                                                     | Description                                                                                                |
+| ---------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `e-error`  | `CustomEvent<{error: Error, source: 'data' \| 'options'}>` | Fired when the `data` or `options` attribute fails to parse as JSON. The internal tree falls back to `[]`. |
+| `e-change` | `CustomEvent<{value: string}>`                             | Fired when the user selects a node. `value` is the node's value.                                           |
 
 ## Slots
 
@@ -33,6 +35,6 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `value` | `string` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `value`  | `string` | no        |             |

--- a/src/components/tree-select.ts
+++ b/src/components/tree-select.ts
@@ -4,6 +4,7 @@ import { TreeView, parseTreeAttr } from '../core/tree';
 
 /**
  * @summary Single-select hierarchical tree with expand/collapse controls.
+ * @since v1.0.1
  *
  * Form-associated: submits the selected node's value.
  *
@@ -12,6 +13,8 @@ import { TreeView, parseTreeAttr } from '../core/tree';
  * @attr {string} [value] - Currently selected node value.
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {string} [default-expanded] - Comma-separated list of node values that are expanded on first render.
+ * @attr {boolean} [required] - Requires a selected tree node.
+ * @attr {string} [required-message] - Message reported when no required node is selected.
  *
  * @fires {CustomEvent<{value: string}>} e-change - Fired when the user selects a node. `value` is the node's value.
  * @fires {CustomEvent<{error: Error, source: 'data' | 'options'}>} e-error - Fired when the `data` or `options` attribute fails to parse as JSON. The internal tree falls back to `[]`.
@@ -20,7 +23,7 @@ import { TreeView, parseTreeAttr } from '../core/tree';
  * <e-tree-select data='[{"value":"a","label":"A","children":[{"value":"a1","label":"A1"}]}]' default-expanded="a"></e-tree-select>
  */
 export class ETreeSelect extends BaseFormControl {
-  static observedAttributes = ['value', 'data', 'options'];
+  static observedAttributes = ['value', 'data', 'options', 'required', 'required-message'];
 
   private _built = false;
   private _view = new TreeView(this, {
@@ -38,6 +41,7 @@ export class ETreeSelect extends BaseFormControl {
       this.internals.setFormValue(this._value);
       this._view.render();
       this._built = true;
+      this._syncValidity();
     }
     this.addEventListener('click', this._onClick);
     this.addEventListener('keydown', this._onKeydown);
@@ -59,6 +63,9 @@ export class ETreeSelect extends BaseFormControl {
       this._value = val ?? '';
       this.internals.setFormValue(this._value);
       this._view.patchSelection(oldVal, this._value);
+      this._syncValidity();
+    } else if (name === 'required' || name === 'required-message') {
+      this._syncValidity();
     }
   }
 
@@ -83,6 +90,7 @@ export class ETreeSelect extends BaseFormControl {
     this._value = v;
     this.internals.setFormValue(v);
     this.setAttribute('value', v);
+    this._syncValidity();
     this.dispatchEvent(new CustomEvent('e-change', { detail: { value: v }, bubbles: true }));
   }
 
@@ -103,6 +111,12 @@ export class ETreeSelect extends BaseFormControl {
   override formResetCallback(): void {
     const dflt = this.getAttribute('default-value') ?? '';
     this.setAttribute('value', dflt);
+  }
+
+  private _syncValidity(): void {
+    const tree = this.querySelector<HTMLElement>('[role="tree"]') ?? undefined;
+    tree?.setAttribute('aria-required', String(this.hasAttribute('required')));
+    this.applyRequiredValidity(!!this._value, tree, 'Please select an option.');
   }
 }
 

--- a/src/components/tree.ts
+++ b/src/components/tree.ts
@@ -7,6 +7,7 @@ type CheckState = 'true' | 'false' | 'mixed';
 
 /**
  * @summary Hierarchical tree for navigation and display, with optional checkboxes.
+ * @since v1.1.0
  *
  * The display counterpart to `<e-tree-select>`: same markup, same keyboard
  * model (arrows, `Home`/`End`, `Enter`/`Space`), but not form-associated. Use

--- a/src/components/upload.md
+++ b/src/components/upload.md
@@ -15,18 +15,20 @@ submitted directly.
 
 ## Attributes
 
-| Attribute | Type | Default | Description |
-| --- | --- | --- | --- |
-| `accept` | `string` | — | Comma-separated MIME types or extensions forwarded to the underlying file input. |
-| `multiple` | `boolean` | — | Accept more than one file. When absent, picking a new file replaces the prior one. |
-| `max-size` | `string` | — | Maximum size per file in bytes. Files exceeding the limit are rejected and the control is marked invalid. |
-| `max-files` | `string` | — | Maximum number of files allowed in multi-file mode. |
-| `name` | `string` | — | Form field name. Required to participate in `FormData`. |
+| Attribute          | Type      | Default | Description                                                                                               |
+| ------------------ | --------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `accept`           | `string`  | —       | Comma-separated MIME types or extensions forwarded to the underlying file input.                          |
+| `multiple`         | `boolean` | —       | Accept more than one file. When absent, picking a new file replaces the prior one.                        |
+| `max-size`         | `string`  | —       | Maximum size per file in bytes. Files exceeding the limit are rejected and the control is marked invalid. |
+| `max-files`        | `string`  | —       | Maximum number of files allowed in multi-file mode.                                                       |
+| `required`         | `boolean` | —       | Requires at least one selected file.                                                                      |
+| `required-message` | `string`  | —       | Message reported when no required file is selected.                                                       |
+| `name`             | `string`  | —       | Form field name. Required to participate in `FormData`.                                                   |
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
+| Event      | Detail                         | Description                                                    |
+| ---------- | ------------------------------ | -------------------------------------------------------------- |
 | `e-change` | `CustomEvent<{files: File[]}>` | Fired whenever the selected file list changes (add or remove). |
 
 ## Slots
@@ -35,7 +37,7 @@ _None._
 
 ## Properties
 
-| Property | Type | Read-only | Description |
-| --- | --- | --- | --- |
-| `_value` | `File[]` | no |  |
-| `value` | `File[]` | no |  |
+| Property | Type     | Read-only | Description |
+| -------- | -------- | --------- | ----------- |
+| `_value` | `File[]` | no        |             |
+| `value`  | `File[]` | no        |             |

--- a/src/components/upload.ts
+++ b/src/components/upload.ts
@@ -4,6 +4,7 @@ import { BaseFormControl } from '../core/base-form-control';
 
 /**
  * @summary Drop-zone file picker with live file list and per-file removal.
+ * @since v1.0.1
  *
  * Form-associated: holds real `File` objects and submits them through
  * `ElementInternals.setFormValue`. In multi-file mode each file is appended
@@ -15,6 +16,8 @@ import { BaseFormControl } from '../core/base-form-control';
  * @attr {string} [name] - Form field name. Required to participate in `FormData`.
  * @attr {string} [max-size] - Maximum size per file in bytes. Files exceeding the limit are rejected and the control is marked invalid.
  * @attr {string} [max-files] - Maximum number of files allowed in multi-file mode.
+ * @attr {boolean} [required] - Requires at least one selected file.
+ * @attr {string} [required-message] - Message reported when no required file is selected.
  *
  * @fires {CustomEvent<{files: File[]}>} e-change - Fired whenever the selected file list changes (add or remove).
  *
@@ -22,7 +25,14 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-upload accept=".pdf,.png" multiple name="docs"></e-upload>
  */
 export class EUpload extends BaseFormControl<File[]> {
-  static observedAttributes = ['accept', 'multiple', 'max-size', 'max-files'];
+  static observedAttributes = [
+    'accept',
+    'multiple',
+    'max-size',
+    'max-files',
+    'required',
+    'required-message',
+  ];
 
   private _wired = false;
   private _hint: HTMLElement | null = null;
@@ -53,6 +63,7 @@ export class EUpload extends BaseFormControl<File[]> {
       this._rebuildList();
     }
     this._syncFormValue();
+    this._validate(this._value);
     this._drop?.addEventListener('click', this._onDropClick);
     this._drop?.addEventListener('keydown', this._onDropKeydown);
     this._drop?.addEventListener('dragover', this._onDragOver);
@@ -102,7 +113,7 @@ export class EUpload extends BaseFormControl<File[]> {
     if (this._input) this._input.value = '';
     this._rebuildList();
     this._syncFormValue();
-    this.internals.setValidity({});
+    this._validate(this._value);
   }
 
   override get value(): File[] {
@@ -180,7 +191,7 @@ export class EUpload extends BaseFormControl<File[]> {
         this.internals.setValidity(
           { customError: true },
           `File "${tooBig.name}" exceeds maximum size of ${maxSize} bytes.`,
-          this._input ?? undefined,
+          this._drop ?? this._input ?? undefined,
         );
         return false;
       }
@@ -189,11 +200,15 @@ export class EUpload extends BaseFormControl<File[]> {
       this.internals.setValidity(
         { customError: true },
         `At most ${maxFiles} file(s) allowed.`,
-        this._input ?? undefined,
+        this._drop ?? this._input ?? undefined,
       );
       return false;
     }
-    this.internals.setValidity({});
+    this.applyRequiredValidity(
+      files.length > 0,
+      this._drop ?? this._input ?? undefined,
+      'Please select a file.',
+    );
     return true;
   }
 
@@ -294,7 +309,7 @@ export class EUpload extends BaseFormControl<File[]> {
     this._rebuildIndices();
     if (this._value.length === 0) this._list.hidden = true;
     this._syncFormValue();
-    this.internals.setValidity({});
+    this._validate(this._value);
     this._emitChange();
   };
 }

--- a/src/components/watermark.ts
+++ b/src/components/watermark.ts
@@ -2,6 +2,7 @@ import { clampedNumAttr, define, esc } from '../core/dom';
 
 /**
  * @summary Repeating background watermark for the host's content area.
+ * @since v1.0.1
  *
  * Renders an SVG-based, tiled watermark behind slotted children. Designed
  * for ownership/draft labels on printable e-paper layouts. The pattern is

--- a/src/core/base-form-control.ts
+++ b/src/core/base-form-control.ts
@@ -61,6 +61,66 @@ export abstract class BaseFormControl<T = string> extends HTMLElement {
     return this.internals.reportValidity();
   }
 
+  /**
+   * Mirror a native inner control's constraint state onto the custom element.
+   * The inner control remains the validation anchor, so the browser can place
+   * its native validation UI next to the actual focus target.
+   */
+  protected mirrorNativeValidity(
+    control: HTMLInputElement | HTMLTextAreaElement,
+    customErrorMessage?: string,
+  ): boolean {
+    if (customErrorMessage) {
+      this.internals.setValidity({ customError: true }, customErrorMessage, control);
+      if (control.getAttribute('aria-invalid') !== 'true')
+        control.setAttribute('aria-invalid', 'true');
+      return false;
+    }
+
+    const validity = control.validity;
+    if (validity.valid) {
+      this.internals.setValidity({});
+      if (control.getAttribute('aria-invalid') === 'true') control.removeAttribute('aria-invalid');
+      return true;
+    }
+
+    const flags: ValidityStateFlags = {};
+    if (validity.badInput) flags.badInput = true;
+    if (validity.customError) flags.customError = true;
+    if (validity.patternMismatch) flags.patternMismatch = true;
+    if (validity.rangeOverflow) flags.rangeOverflow = true;
+    if (validity.rangeUnderflow) flags.rangeUnderflow = true;
+    if (validity.stepMismatch) flags.stepMismatch = true;
+    if (validity.tooLong) flags.tooLong = true;
+    if (validity.tooShort) flags.tooShort = true;
+    if (validity.typeMismatch) flags.typeMismatch = true;
+    if (validity.valueMissing) flags.valueMissing = true;
+    this.internals.setValidity(flags, control.validationMessage, control);
+    if (control.getAttribute('aria-invalid') !== 'true')
+      control.setAttribute('aria-invalid', 'true');
+    return false;
+  }
+
+  /** Apply the shared `required` contract for non-native composite controls. */
+  protected applyRequiredValidity(
+    hasValue: boolean,
+    anchor?: HTMLElement,
+    defaultMessage = 'Please fill out this field.',
+  ): boolean {
+    const missing = this.hasAttribute('required') && !hasValue;
+    if (missing) {
+      const message = this.getAttribute('required-message') || defaultMessage;
+      this.internals.setValidity({ valueMissing: true }, message, anchor);
+      if (anchor?.getAttribute('aria-invalid') !== 'true') {
+        anchor?.setAttribute('aria-invalid', 'true');
+      }
+      return false;
+    }
+    this.internals.setValidity({});
+    if (anchor?.getAttribute('aria-invalid') === 'true') anchor.removeAttribute('aria-invalid');
+    return true;
+  }
+
   /** Keep subclass UI in sync when a containing fieldset disables the control. */
   formDisabledCallback(disabled: boolean): void {
     this._formDisabled = disabled;

--- a/src/site/data.ts
+++ b/src/site/data.ts
@@ -175,7 +175,7 @@ export interface RoadmapItem {
 
 /** Lede above the roadmap. Real prose, because AI crawlers quote prose. */
 export const ROADMAP_INTRO =
-  'EPaper follows semantic versioning. Patch releases ship from every green run on main under the npm dev tag; tagged releases publish to latest.';
+  'EPaper follows an outcome-based roadmap. The next release strengthens native form behaviour, ships panel-specific themes and makes the e-paper refresh cost of interactions measurable in CI.';
 
 export const ROADMAP: RoadmapItem[] = [
   {
@@ -186,18 +186,13 @@ export const ROADMAP: RoadmapItem[] = [
   },
   {
     time: 'V1.1',
-    title: 'Theme Pack',
-    body: 'Additional token packs for Kaleido panels and high-contrast monochrome.',
+    title: 'Reliability & panel themes',
+    body: 'Unified native constraint validation, high-contrast monochrome and Kaleido theme packs, plus automated refresh-budget checks.',
   },
   {
-    time: 'V1.2',
-    title: 'Storybook 9',
-    body: 'Upgrade Storybook devDependency to 9.x and bundle a hosted demo.',
-  },
-  {
-    time: 'V2.0',
-    title: 'SSR helpers',
-    body: 'Optional SSR helpers for declarative-shadow-dom-free hydration on edge runtimes.',
+    time: 'Later',
+    title: 'Hardware integrations',
+    body: 'Driver adapters and SSR helpers will follow real deployment demand instead of being committed to a version prematurely.',
   },
 ];
 
@@ -235,10 +230,10 @@ export const TABLE_ROWS: Array<Record<string, string | number>> = [
 ];
 
 export const CALENDAR_EVENTS: CalendarEvent[] = [
-  { date: '2026-04-29', title: 'V1.1 release' },
-  { date: '2026-05-12', title: 'Storybook upgrade' },
+  { date: '2026-04-29', title: 'Panel field test' },
+  { date: '2026-05-12', title: 'Accessibility review' },
   { date: '2026-05-22', title: 'Office hours' },
-  { date: '2026-04-30', title: 'Roadmap review' },
+  { date: '2026-04-30', title: 'Design review' },
 ];
 
 export const INSTALL_SNIPPETS = {

--- a/src/stories/Tokens.stories.ts
+++ b/src/stories/Tokens.stories.ts
@@ -40,7 +40,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Single source of truth for the visual system. Every component reads from these CSS custom properties — never hard-coded values — so re-skinning the library is a matter of overriding tokens at the page or component level. The system is intentionally narrow: no light/dark theme, no semantic alias layer, only five accent colors.',
+          '**Version:** v1.0.1\n\nSingle source of truth for the visual system. Every component reads from these CSS custom properties — never hard-coded values — so re-skinning the library is a matter of overriding tokens at the page or component level. The system is intentionally narrow: no light/dark theme, no semantic alias layer, only five accent colors.',
       },
     },
   },

--- a/src/stories/composite/FloatButton.stories.ts
+++ b/src/stories/composite/FloatButton.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Fixed-position circular action button anchored to a viewport corner. Surfaces a top-priority action (e.g. compose, add) without taking space in the document flow.',
+          '**Version:** v1.0.1\n\nFixed-position circular action button anchored to a viewport corner. Surfaces a top-priority action (e.g. compose, add) without taking space in the document flow.',
       },
     },
   },

--- a/src/stories/composite/Form.stories.ts
+++ b/src/stories/composite/Form.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Form layout with consistent label/control rows, hint text and validation messaging. Use `stacked` for most cases and `inline` for filter bars or single-row queries.',
+          '**Version:** v1.0.1\n\nForm layout with consistent label/control rows, hint text and validation messaging. Use `stacked` for most cases and `inline` for filter bars or single-row queries.',
       },
     },
   },

--- a/src/stories/composite/Upload.stories.ts
+++ b/src/stories/composite/Upload.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'File upload control with both click-to-browse and drag-and-drop targets, plus an inline file list. Restrict file types via the `accept` attribute and toggle `multiple` for batch uploads.',
+          '**Version:** v1.0.1\n\nFile upload control with both click-to-browse and drag-and-drop targets, plus an inline file list. Restrict file types via the `accept` attribute and toggle `multiple` for batch uploads.',
       },
     },
   },

--- a/src/stories/display/Avatar.stories.ts
+++ b/src/stories/display/Avatar.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'User or entity portrait. Falls back from image (`src`) to derived initials based on `name`. Supports any pixel size and either a `square` or `circle` shape.',
+          '**Version:** v1.0.1\n\nUser or entity portrait. Falls back from image (`src`) to derived initials based on `name`. Supports any pixel size and either a `square` or `circle` shape.',
       },
     },
   },

--- a/src/stories/display/Calendar.stories.ts
+++ b/src/stories/display/Calendar.stories.ts
@@ -17,7 +17,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Month-grid date display. Read-only by default; supply `events` (a JSON array of `{ date, title }`) to mark dated entries. Useful for editorial calendars, schedules and date overviews.',
+          '**Version:** v1.0.1\n\nMonth-grid date display. Read-only by default; supply `events` (a JSON array of `{ date, title }`) to mark dated entries. Useful for editorial calendars, schedules and date overviews.',
       },
     },
   },

--- a/src/stories/display/Card.stories.ts
+++ b/src/stories/display/Card.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Framed container with optional eyebrow, title and slotted body content. Uses the standard 2 px ink border so cards line up with the rest of the system.',
+          '**Version:** v1.0.1\n\nFramed container with optional eyebrow, title and slotted body content. Uses the standard 2 px ink border so cards line up with the rest of the system.',
       },
     },
   },

--- a/src/stories/display/CardImage.stories.ts
+++ b/src/stories/display/CardImage.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Card variant with a leading hero region — either an image URL or the built-in diagonal `hatch` cover for editorial layouts. Pairs well with Ribbon for featured items.',
+          '**Version:** v1.0.1\n\nCard variant with a leading hero region — either an image URL or the built-in diagonal `hatch` cover for editorial layouts. Pairs well with Ribbon for featured items.',
       },
     },
   },

--- a/src/stories/display/Collapse.stories.ts
+++ b/src/stories/display/Collapse.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Stack of expandable sections built on native `<details>`/`<summary>`. Expanding a section mutates one `open` attribute, so the panel repaints only the section that changed instead of reflowing the page — which is what makes a collapse a better fit than a scrolling wall of text on e-paper. Keyboard support, the accessible name and find-in-page all come from the native element.',
+          '**Version:** v1.1.0\n\nStack of expandable sections built on native `<details>`/`<summary>`. Expanding a section mutates one `open` attribute, so the panel repaints only the section that changed instead of reflowing the page — which is what makes a collapse a better fit than a scrolling wall of text on e-paper. Keyboard support, the accessible name and find-in-page all come from the native element.',
       },
     },
   },

--- a/src/stories/display/DescriptionList.stories.ts
+++ b/src/stories/display/DescriptionList.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Semantic key/value list rendered with a `<dl>`. Prefer this over a raw `<dl>` when you want consistent layout, optional borders and a multi-column grid.',
+          '**Version:** v1.0.1\n\nSemantic key/value list rendered with a `<dl>`. Prefer this over a raw `<dl>` when you want consistent layout, optional borders and a multi-column grid.',
       },
     },
   },

--- a/src/stories/display/Empty.stories.ts
+++ b/src/stories/display/Empty.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Empty-state placeholder with icon, title, optional description and an action slot. Use as the body of a list, table or section that has no content yet.',
+          '**Version:** v1.0.1\n\nEmpty-state placeholder with icon, title, optional description and an action slot. Use as the body of a list, table or section that has no content yet.',
       },
     },
   },

--- a/src/stories/display/Image.stories.ts
+++ b/src/stories/display/Image.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Image wrapper with native lazy-loading, fallback source and optional caption. On error, swaps to `fallback`; if that fails too, shows a hatched placeholder.',
+          '**Version:** v1.0.1\n\nImage wrapper with native lazy-loading, fallback source and optional caption. On error, swaps to `fallback`; if that fails too, shows a hatched placeholder.',
       },
     },
   },

--- a/src/stories/display/Kaleido.stories.ts
+++ b/src/stories/display/Kaleido.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Showcase swatch for the five Kaleido accent colors (red, orange, yellow, green, blue). These are the **only** fills permitted in the system and are reserved for state — destructive, warning, attention, success, link/info.',
+          '**Version:** v1.0.1\n\nShowcase swatch for the five Kaleido accent colors (red, orange, yellow, green, blue). These are the **only** fills permitted in the system and are reserved for state — destructive, warning, attention, success, link/info.',
       },
     },
   },

--- a/src/stories/display/List.stories.ts
+++ b/src/stories/display/List.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Structured list with optional header / footer slots and slot-driven `<e-list-item>` rows. Use this instead of a native `<ul>` when you need leading / trailing content per row.',
+          '**Version:** v1.0.1\n\nStructured list with optional header / footer slots and slot-driven `<e-list-item>` rows. Use this instead of a native `<ul>` when you need leading / trailing content per row.',
       },
     },
   },

--- a/src/stories/display/Popover.stories.ts
+++ b/src/stories/display/Popover.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Click-triggered overlay panel anchored to its trigger — the counterpart to a tooltip for hardware that has no hover. Capacitive e-paper digitizers report contact, not proximity, so anything that would be revealed on hover has to be revealed on tap instead. Content is arbitrary, which separates this from `<e-dropdown>` (a list of commands). The panel is non-modal and does not trap focus; reach for `<e-dialog>` when the user must deal with it before continuing.',
+          '**Version:** v1.1.0\n\nClick-triggered overlay panel anchored to its trigger — the counterpart to a tooltip for hardware that has no hover. Capacitive e-paper digitizers report contact, not proximity, so anything that would be revealed on hover has to be revealed on tap instead. Content is arbitrary, which separates this from `<e-dropdown>` (a list of commands). The panel is non-modal and does not trap focus; reach for `<e-dialog>` when the user must deal with it before continuing.',
       },
     },
   },

--- a/src/stories/display/Progress.stories.ts
+++ b/src/stories/display/Progress.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Static progress indicator. Renders as a linear bar or as discrete steps. No animation: the bar updates as a single dirty rectangle for partial-refresh-friendly behaviour.',
+          '**Version:** v1.0.1\n\nStatic progress indicator. Renders as a linear bar or as discrete steps. No animation: the bar updates as a single dirty rectangle for partial-refresh-friendly behaviour.',
       },
     },
   },

--- a/src/stories/display/QRCode.stories.ts
+++ b/src/stories/display/QRCode.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Pure-SVG QR code renderer with zero runtime dependencies. Ideal for e-paper devices: every module is a sharp 1-bit cell.',
+          '**Version:** v1.0.1\n\nPure-SVG QR code renderer with zero runtime dependencies. Ideal for e-paper devices: every module is a sharp 1-bit cell.',
       },
     },
   },

--- a/src/stories/display/Result.stories.ts
+++ b/src/stories/display/Result.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Status page block (success / error / 404 / info / warning). Composes an icon, large title, optional description and a slotted action area.',
+          '**Version:** v1.0.1\n\nStatus page block (success / error / 404 / info / warning). Composes an icon, large title, optional description and a slotted action area.',
       },
     },
   },

--- a/src/stories/display/Segmented.stories.ts
+++ b/src/stories/display/Segmented.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Single-select control rendered as a flat row of mutually-exclusive segments. Use it as a lightweight alternative to Tabs or RadioGroup when options are short labels.',
+          '**Version:** v1.0.1\n\nSingle-select control rendered as a flat row of mutually-exclusive segments. Use it as a lightweight alternative to Tabs or RadioGroup when options are short labels.',
       },
     },
   },

--- a/src/stories/display/Skeleton.stories.ts
+++ b/src/stories/display/Skeleton.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Static loading placeholder. Pure outline — no shimmer, no animation. Use to reserve space while content loads. Avoids triggering a full GC16 refresh on e-paper.',
+          '**Version:** v1.0.1\n\nStatic loading placeholder. Pure outline — no shimmer, no animation. Use to reserve space while content loads. Avoids triggering a full GC16 refresh on e-paper.',
       },
     },
   },

--- a/src/stories/display/Statistic.stories.ts
+++ b/src/stories/display/Statistic.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'KPI block: large numeric value with label and an optional trend marker. The trend glyph is static (no animation) so it does not provoke an e-paper full refresh.',
+          '**Version:** v1.0.1\n\nKPI block: large numeric value with label and an optional trend marker. The trend glyph is static (no animation) so it does not provoke an e-paper full refresh.',
       },
     },
   },

--- a/src/stories/display/Table.stories.ts
+++ b/src/stories/display/Table.stories.ts
@@ -22,7 +22,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Data grid with header, optional sort and row selection. Sort is **static**: clicking a header cycles `none → asc → desc → none` and emits `e-sort` — owners decide whether to re-sort or re-fetch.',
+          '**Version:** v1.0.1\n\nData grid with header, optional sort and row selection. Sort is **static**: clicking a header cycles `none → asc → desc → none` and emits `e-sort` — owners decide whether to re-sort or re-fetch.',
       },
     },
   },

--- a/src/stories/display/Tag.stories.ts
+++ b/src/stories/display/Tag.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Small inline label, optionally removable. Use to mark categories or filters that the user can dismiss. Distinct from `<e-badge>`, which is purely decorative.',
+          '**Version:** v1.0.1\n\nSmall inline label, optionally removable. Use to mark categories or filters that the user can dismiss. Distinct from `<e-badge>`, which is purely decorative.',
       },
     },
   },

--- a/src/stories/display/Timeline.stories.ts
+++ b/src/stories/display/Timeline.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Vertical event list with a hairline rail and bullet markers. Use for activity feeds, audit logs or order tracking. Static layout — no animations.',
+          '**Version:** v1.0.1\n\nVertical event list with a hairline rail and bullet markers. Use for activity feeds, audit logs or order tracking. Static layout — no animations.',
       },
     },
   },

--- a/src/stories/display/Tree.stories.ts
+++ b/src/stories/display/Tree.stories.ts
@@ -29,7 +29,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Hierarchical tree for navigation and display — the counterpart to `<e-tree-select>`, sharing its markup and keyboard model (arrows, `Home`/`End`, `Enter`/`Space`) but not form-associated. Expanding a node materialises its children on first open and toggles `hidden` afterwards, so a deep tree costs one small dirty rectangle per interaction rather than a full re-render.',
+          '**Version:** v1.1.0\n\nHierarchical tree for navigation and display — the counterpart to `<e-tree-select>`, sharing its markup and keyboard model (arrows, `Home`/`End`, `Enter`/`Space`) but not form-associated. Expanding a node materialises its children on first open and toggles `hidden` afterwards, so a deep tree costs one small dirty rectangle per interaction rather than a full re-render.',
       },
     },
   },

--- a/src/stories/feedback/Alert.stories.ts
+++ b/src/stories/feedback/Alert.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Inline status banner. The static counterpart to a toast — nothing appears or disappears on a timer, because a message that auto-dismisses can be missed entirely between two panel refreshes. Severity is carried by an icon, a border weight and a hatch fill, never by color alone. Use `<e-result>` instead when the message *is* the page.',
+          '**Version:** v1.1.0\n\nInline status banner. The static counterpart to a toast — nothing appears or disappears on a timer, because a message that auto-dismisses can be missed entirely between two panel refreshes. Severity is carried by an icon, a border weight and a hatch fill, never by color alone. Use `<e-result>` instead when the message *is* the page.',
       },
     },
   },

--- a/src/stories/feedback/Dialog.stories.ts
+++ b/src/stories/feedback/Dialog.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Modal dialog built on the native `<dialog>` element, opened through `showModal()`. Focus trapping, `Escape` handling, the top layer and inertness of the page behind it come from the browser. A modal is a deliberate context switch, which is the one place a full-panel refresh is appropriate on e-paper — so the backdrop is a flat hatch fill, never a translucent wash, which would dither unpredictably between refreshes.',
+          '**Version:** v1.1.0\n\nModal dialog built on the native `<dialog>` element, opened through `showModal()`. Focus trapping, `Escape` handling, the top layer and inertness of the page behind it come from the browser. A modal is a deliberate context switch, which is the one place a full-panel refresh is appropriate on e-paper — so the backdrop is a flat hatch fill, never a translucent wash, which would dither unpredictably between refreshes.',
       },
     },
   },

--- a/src/stories/feedback/Popconfirm.stories.ts
+++ b/src/stories/feedback/Popconfirm.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Inline confirmation bubble anchored to the control that triggers it. A lighter alternative to `<e-dialog>` for a single destructive action: no backdrop, no full-panel refresh, just a small dirty rectangle next to the button. Undo is expensive on e-paper, which makes confirming worth more than it is on desktop — but a full modal flash for a one-line question is not.',
+          '**Version:** v1.0.1\n\nInline confirmation bubble anchored to the control that triggers it. A lighter alternative to `<e-dialog>` for a single destructive action: no backdrop, no full-panel refresh, just a small dirty rectangle next to the button. Undo is expensive on e-paper, which makes confirming worth more than it is on desktop — but a full modal flash for a one-line question is not.',
       },
     },
   },

--- a/src/stories/inputs/Cascader.stories.ts
+++ b/src/stories/inputs/Cascader.stories.ts
@@ -43,7 +43,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Tiered select that drills into multi-level options column-by-column (e.g. country → region → city). The committed value is the full path joined with commas.',
+          '**Version:** v1.0.1\n\nTiered select that drills into multi-level options column-by-column (e.g. country → region → city). The committed value is the full path joined with commas.',
       },
     },
   },

--- a/src/stories/inputs/Checkbox.stories.ts
+++ b/src/stories/inputs/Checkbox.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Single binary on/off control with a flat ink check. Pair with a label or compose multiple instances inside a CheckboxGroup.',
+          '**Version:** v1.0.1\n\nSingle binary on/off control with a flat ink check. Pair with a label or compose multiple instances inside a CheckboxGroup.',
       },
     },
   },

--- a/src/stories/inputs/CheckboxGroup.stories.ts
+++ b/src/stories/inputs/CheckboxGroup.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Collection of related checkboxes managed as one form field. Lays out children either vertically (default) or horizontally, exposing the joined selection as a comma-separated string.',
+          '**Version:** v1.0.1\n\nCollection of related checkboxes managed as one form field. Lays out children either vertically (default) or horizontally, exposing the joined selection as a comma-separated string.',
       },
     },
   },

--- a/src/stories/inputs/Chip.stories.ts
+++ b/src/stories/inputs/Chip.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Selectable label for filters or quick choices. Toggles `selected` on click and fires `e-change`. Distinct from `<e-tag>` (removable label) and `<e-badge>` (decorative).',
+          '**Version:** v1.0.1\n\nSelectable label for filters or quick choices. Toggles `selected` on click and fires `e-change`. Distinct from `<e-tag>` (removable label) and `<e-badge>` (decorative).',
       },
     },
   },

--- a/src/stories/inputs/DatePicker.stories.ts
+++ b/src/stories/inputs/DatePicker.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Text field paired with a popover month calendar for picking a single date. Values are exchanged as ISO `YYYY-MM-DD` strings.',
+          '**Version:** v1.0.1\n\nText field paired with a popover month calendar for picking a single date. Values are exchanged as ISO `YYYY-MM-DD` strings.',
       },
     },
   },

--- a/src/stories/inputs/Input.stories.ts
+++ b/src/stories/inputs/Input.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Single-line text field with built-in label, placeholder, hint and error states. Setting `error` switches the border to the error treatment and wires `aria-invalid` automatically.',
+          '**Version:** v1.0.1\n\nSingle-line text field with built-in label, placeholder, hint and error states. Setting `error` switches the border to the error treatment and wires `aria-invalid` automatically.',
       },
     },
   },

--- a/src/stories/inputs/InputNumber.stories.ts
+++ b/src/stories/inputs/InputNumber.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Numeric input with stepper buttons. Supports `min`, `max` and `step` constraints and clamps the value on commit.',
+          '**Version:** v1.0.1\n\nNumeric input with stepper buttons. Supports `min`, `max` and `step` constraints and clamps the value on commit.',
       },
     },
   },

--- a/src/stories/inputs/RadioGroup.stories.ts
+++ b/src/stories/inputs/RadioGroup.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Single-select control rendered as a list of radio options. Use when the user needs to see all available choices at once.',
+          '**Version:** v1.0.1\n\nSingle-select control rendered as a list of radio options. Use when the user needs to see all available choices at once.',
       },
     },
   },

--- a/src/stories/inputs/Select.stories.ts
+++ b/src/stories/inputs/Select.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Drop-down list for choosing one option from a closed set. Prefer over RadioGroup once the option count gets long enough that scanning becomes expensive (~6+ items).',
+          '**Version:** v1.0.1\n\nDrop-down list for choosing one option from a closed set. Prefer over RadioGroup once the option count gets long enough that scanning becomes expensive (~6+ items).',
       },
     },
   },

--- a/src/stories/inputs/Textarea.stories.ts
+++ b/src/stories/inputs/Textarea.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Multi-line text field for longer-form input such as comments, descriptions or messages. Shares the Input visual treatment.',
+          '**Version:** v1.0.1\n\nMulti-line text field for longer-form input such as comments, descriptions or messages. Shares the Input visual treatment.',
       },
     },
   },

--- a/src/stories/inputs/TimePicker.stories.ts
+++ b/src/stories/inputs/TimePicker.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Text field paired with an hour/minute popover for picking a time. Values are exchanged as 24-hour `HH:MM` strings.',
+          '**Version:** v1.0.1\n\nText field paired with an hour/minute popover for picking a time. Values are exchanged as 24-hour `HH:MM` strings.',
       },
     },
   },

--- a/src/stories/inputs/Toggle.stories.ts
+++ b/src/stories/inputs/Toggle.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Two-state switch for binary settings that take effect immediately. Use as an alternative to Checkbox in settings panels and toolbars.',
+          '**Version:** v1.0.1\n\nTwo-state switch for binary settings that take effect immediately. Use as an alternative to Checkbox in settings panels and toolbars.',
       },
     },
   },

--- a/src/stories/inputs/TreeSelect.stories.ts
+++ b/src/stories/inputs/TreeSelect.stories.ts
@@ -38,7 +38,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Select that exposes a hierarchical tree of options collapsible by branch. Useful for taxonomies, org charts or geo selectors where parent/child context matters.',
+          '**Version:** v1.0.1\n\nSelect that exposes a hierarchical tree of options collapsible by branch. Useful for taxonomies, org charts or geo selectors where parent/child context matters.',
       },
     },
   },

--- a/src/stories/layout/Affix.stories.ts
+++ b/src/stories/layout/Affix.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Wraps content in a CSS `position: sticky` container. Pure CSS — no scroll listeners, no e-paper waveform on scroll.',
+          '**Version:** v1.0.1\n\nWraps content in a CSS `position: sticky` container. Pure CSS — no scroll listeners, no e-paper waveform on scroll.',
       },
     },
   },

--- a/src/stories/layout/Divider.stories.ts
+++ b/src/stories/layout/Divider.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Horizontal or vertical rule used to separate sections. Supports `solid` and `dashed` strokes and an optional centered inline label.',
+          '**Version:** v1.0.1\n\nHorizontal or vertical rule used to separate sections. Supports `solid` and `dashed` strokes and an optional centered inline label.',
       },
     },
   },

--- a/src/stories/layout/Flex.stories.ts
+++ b/src/stories/layout/Flex.stories.ts
@@ -13,7 +13,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'One-dimensional flexbox container. Exposes attributes for `direction`, `wrap`, `gap`, `justify` and `align` so layout stays declarative — no ad-hoc inline styles.',
+          '**Version:** v1.0.1\n\nOne-dimensional flexbox container. Exposes attributes for `direction`, `wrap`, `gap`, `justify` and `align` so layout stays declarative — no ad-hoc inline styles.',
       },
     },
   },

--- a/src/stories/layout/Grid.stories.ts
+++ b/src/stories/layout/Grid.stories.ts
@@ -18,7 +18,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Two-dimensional CSS-grid container. Compose with `<e-grid-item col="span N">` to lay out cells. Use the `cols` and `gap` attributes to drive the track count and spacing.',
+          '**Version:** v1.0.1\n\nTwo-dimensional CSS-grid container. Compose with `<e-grid-item col="span N">` to lay out cells. Use the `cols` and `gap` attributes to drive the track count and spacing.',
       },
     },
   },

--- a/src/stories/layout/Layout.stories.ts
+++ b/src/stories/layout/Layout.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Page chrome scaffold composed of optional `<e-header>`, `<e-sider>`, `<e-content>` and `<e-footer>` regions. Provides the top-level frame for application screens.',
+          '**Version:** v1.0.1\n\nPage chrome scaffold composed of optional `<e-header>`, `<e-sider>`, `<e-content>` and `<e-footer>` regions. Provides the top-level frame for application screens.',
       },
     },
   },

--- a/src/stories/layout/Masonry.stories.ts
+++ b/src/stories/layout/Masonry.stories.ts
@@ -20,7 +20,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Pinterest-style multi-column layout that packs items of varying heights without leaving gaps. Configurable column count and inter-item spacing.',
+          '**Version:** v1.0.1\n\nPinterest-style multi-column layout that packs items of varying heights without leaving gaps. Configurable column count and inter-item spacing.',
       },
     },
   },

--- a/src/stories/layout/Space.stories.ts
+++ b/src/stories/layout/Space.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Inline gap utility that distributes equal spacing between children. Lighter than Flex when all you need is a consistent gutter between elements.',
+          '**Version:** v1.0.1\n\nInline gap utility that distributes equal spacing between children. Lighter than Flex when all you need is a consistent gutter between elements.',
       },
     },
   },

--- a/src/stories/layout/Splitter.stories.ts
+++ b/src/stories/layout/Splitter.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Resizable two-pane layout with a draggable divider. Supports horizontal and vertical orientations plus min-size constraints so panes can’t be collapsed past a usable width.',
+          '**Version:** v1.0.1\n\nResizable two-pane layout with a draggable divider. Supports horizontal and vertical orientations plus min-size constraints so panes can’t be collapsed past a usable width.',
       },
     },
   },

--- a/src/stories/layout/Watermark.stories.ts
+++ b/src/stories/layout/Watermark.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Tiled SVG watermark layered behind slotted content. Designed for print-style "DRAFT" / "CONFIDENTIAL" labels on e-paper layouts.',
+          '**Version:** v1.0.1\n\nTiled SVG watermark layered behind slotted content. Designed for print-style "DRAFT" / "CONFIDENTIAL" labels on e-paper layouts.',
       },
     },
   },

--- a/src/stories/navigation/Anchor.stories.ts
+++ b/src/stories/navigation/Anchor.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'In-page navigation that highlights the section currently in view as the user scrolls. Useful for long documentation or article pages.',
+          '**Version:** v1.0.1\n\nIn-page navigation that highlights the section currently in view as the user scrolls. Useful for long documentation or article pages.',
       },
     },
   },

--- a/src/stories/navigation/BackTop.stories.ts
+++ b/src/stories/navigation/BackTop.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Floating button that scrolls the window (or a target container) to the top. Hidden until the user has scrolled past `visibility-height`.',
+          '**Version:** v1.0.1\n\nFloating button that scrolls the window (or a target container) to the top. Hidden until the user has scrolled past `visibility-height`.',
       },
     },
   },

--- a/src/stories/navigation/Breadcrumb.stories.ts
+++ b/src/stories/navigation/Breadcrumb.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Hierarchical trail showing the user’s location within nested pages. The last item represents the current page and is rendered as plain text.',
+          '**Version:** v1.0.1\n\nHierarchical trail showing the user’s location within nested pages. The last item represents the current page and is rendered as plain text.',
       },
     },
   },

--- a/src/stories/navigation/Dropdown.stories.ts
+++ b/src/stories/navigation/Dropdown.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Lightweight menu that opens from a trigger button to expose secondary actions, filters, or sort options. Closes on outside click and Escape.',
+          '**Version:** v1.0.1\n\nLightweight menu that opens from a trigger button to expose secondary actions, filters, or sort options. Closes on outside click and Escape.',
       },
     },
   },

--- a/src/stories/navigation/Menu.stories.ts
+++ b/src/stories/navigation/Menu.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Navigation container with vertical or horizontal layout. Items support icons, badges and one level of nested children. The active item is reflected through `aria-current="page"`.',
+          '**Version:** v1.0.1\n\nNavigation container with vertical or horizontal layout. Items support icons, badges and one level of nested children. The active item is reflected through `aria-current="page"`.',
       },
     },
   },

--- a/src/stories/navigation/Pagination.stories.ts
+++ b/src/stories/navigation/Pagination.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Page-list control for paged data sets. Provides previous/next buttons, direct page jumps and an ellipsis when the page count exceeds the visible window.',
+          '**Version:** v1.0.1\n\nPage-list control for paged data sets. Provides previous/next buttons, direct page jumps and an ellipsis when the page count exceeds the visible window.',
       },
     },
   },

--- a/src/stories/navigation/Steps.stories.ts
+++ b/src/stories/navigation/Steps.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Sequential progress indicator for multi-step flows such as onboarding, checkout or wizards. Renders horizontally by default; switch to `vertical` for tall sidebars.',
+          '**Version:** v1.0.1\n\nSequential progress indicator for multi-step flows such as onboarding, checkout or wizards. Renders horizontally by default; switch to `vertical` for tall sidebars.',
       },
     },
   },

--- a/src/stories/navigation/Tabs.stories.ts
+++ b/src/stories/navigation/Tabs.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Switcher between sibling content panes with an underline-style active indicator. Implements WAI-ARIA tabs pattern with full keyboard support (← → Home End).',
+          '**Version:** v1.0.1\n\nSwitcher between sibling content panes with an underline-style active indicator. Implements WAI-ARIA tabs pattern with full keyboard support (← → Home End).',
       },
     },
   },

--- a/src/stories/primitives/Badge.stories.ts
+++ b/src/stories/primitives/Badge.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Decorative text label used to mark status, categories or counts. Pure ink — no fill colors, just a flat outlined chip. Use the `inverted` variant for emphasis on light surfaces.',
+          '**Version:** v1.0.1\n\nDecorative text label used to mark status, categories or counts. Pure ink — no fill colors, just a flat outlined chip. Use the `inverted` variant for emphasis on light surfaces.',
       },
     },
   },

--- a/src/stories/primitives/BadgeCount.stories.ts
+++ b/src/stories/primitives/BadgeCount.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Compact numeric indicator for unread or new-item counts. Renders as a small filled chip overflowing past `max` (default 99) or as a simple dot when `dot` is set. Typically overlaid on icons, avatars, or menu items.',
+          '**Version:** v1.0.1\n\nCompact numeric indicator for unread or new-item counts. Renders as a small filled chip overflowing past `max` (default 99) or as a simple dot when `dot` is set. Typically overlaid on icons, avatars, or menu items.',
       },
     },
   },

--- a/src/stories/primitives/Button.stories.ts
+++ b/src/stories/primitives/Button.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Primary interactive control for triggering actions. Three visual variants — `primary` (filled ink), `secondary` (outlined), and `destructive` (hatched) — plus a disabled state. Always meets the 44 px hit-target token.',
+          '**Version:** v1.0.1\n\nPrimary interactive control for triggering actions. Three visual variants — `primary` (filled ink), `secondary` (outlined), and `destructive` (hatched) — plus a disabled state. Always meets the 44 px hit-target token.',
       },
     },
   },

--- a/src/stories/primitives/Icon.stories.ts
+++ b/src/stories/primitives/Icon.stories.ts
@@ -54,7 +54,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Monochrome line icon rendered as inline SVG from the built-in icon set. Sized in pixels (default 20) and styled with the current ink color. Provide a `label` whenever the icon is the only thing conveying meaning.',
+          '**Version:** v1.0.1\n\nMonochrome line icon rendered as inline SVG from the built-in icon set. Sized in pixels (default 20) and styled with the current ink color. Provide a `label` whenever the icon is the only thing conveying meaning.',
       },
     },
   },

--- a/src/stories/primitives/Ribbon.stories.ts
+++ b/src/stories/primitives/Ribbon.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Diagonal corner banner attached to a parent container — typically a card. Used sparingly for promotions, status flags or “new” callouts.',
+          '**Version:** v1.0.1\n\nDiagonal corner banner attached to a parent container — typically a card. Used sparingly for promotions, status flags or “new” callouts.',
       },
     },
   },

--- a/src/stories/typography/Link.stories.ts
+++ b/src/stories/typography/Link.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Inline anchor styled with the system’s underline + ink-fg colour. Set `underline` when you need to force a visible underline outside flowing prose.',
+          '**Version:** v1.0.1\n\nInline anchor styled with the system’s underline + ink-fg colour. Set `underline` when you need to force a visible underline outside flowing prose.',
       },
     },
   },

--- a/src/stories/typography/Text.stories.ts
+++ b/src/stories/typography/Text.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Body-text element bound to the system type scale. Pick a `kind` (`body`, `prose`, `small`, `mono`, `label`) to map onto the matching `--ink-text-*` token and line-height.',
+          '**Version:** v1.0.1\n\nBody-text element bound to the system type scale. Pick a `kind` (`body`, `prose`, `small`, `mono`, `label`) to map onto the matching `--ink-text-*` token and line-height.',
       },
     },
   },

--- a/src/stories/typography/Title.stories.ts
+++ b/src/stories/typography/Title.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Heading element across the H1–H6 scale. The `level` attribute drives both the rendered tag (for semantics) and the `--ink-text-h*` token used for sizing.',
+          '**Version:** v1.0.1\n\nHeading element across the H1–H6 scale. The `level` attribute drives both the rendered tag (for semantics) and the `--ink-text-h*` token used for sizing.',
       },
     },
   },

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1928,7 +1928,7 @@ e-text {
 }
 .ink-progress__fill {
   height: 100%;
-  background: var(--ink-fg);
+  background: var(--ink-accent);
 }
 .ink-progress__steps {
   display: grid;
@@ -1944,7 +1944,7 @@ e-text {
   box-sizing: border-box;
 }
 .ink-progress__seg[data-on] {
-  background: var(--ink-fg);
+  background: var(--ink-accent);
 }
 .ink-progress__label {
   margin-top: 6px;
@@ -1979,14 +1979,19 @@ e-text {
 }
 .ink-result[data-status='success'] .ink-result__icon,
 .ink-result[data-status='404'] .ink-result__icon {
-  background: var(--ink-fg);
+  background: var(--ink-success);
   color: var(--ink-bg);
+  border-color: var(--ink-success);
 }
 .ink-result[data-status='error'] .ink-result__icon {
   background-image: var(--ink-hatch-error);
+  border-color: var(--ink-danger);
+  color: var(--ink-danger);
 }
 .ink-result[data-status='warning'] .ink-result__icon {
   background-image: var(--ink-hatch-disabled);
+  border-color: var(--ink-warning);
+  color: var(--ink-warning);
 }
 .ink-result__title {
   font-family: var(--ink-serif);
@@ -2597,9 +2602,16 @@ e-text {
 }
 .ink-alert[data-variant='warning'] {
   border-width: var(--ink-border-width-strong);
+  border-color: var(--ink-warning);
 }
 .ink-alert[data-variant='error'] {
-  border: var(--ink-border-width-error) solid var(--ink-fg);
+  border: var(--ink-border-width-error) solid var(--ink-danger);
+}
+.ink-alert[data-variant='info'] {
+  border-color: var(--ink-info);
+}
+.ink-alert[data-variant='success'] {
+  border-color: var(--ink-success);
 }
 .ink-alert__icon {
   display: inline-flex;
@@ -2612,11 +2624,22 @@ e-text {
   background: var(--ink-bg);
 }
 .ink-alert[data-variant='success'] .ink-alert__icon {
-  background: var(--ink-fg);
+  background: var(--ink-success);
   color: var(--ink-bg);
+  border-color: var(--ink-success);
+}
+.ink-alert[data-variant='info'] .ink-alert__icon {
+  border-color: var(--ink-info);
+  color: var(--ink-info);
+}
+.ink-alert[data-variant='warning'] .ink-alert__icon {
+  border-color: var(--ink-warning);
+  color: var(--ink-warning);
 }
 .ink-alert[data-variant='error'] .ink-alert__icon {
   background-image: var(--ink-hatch-error);
+  border-color: var(--ink-danger);
+  color: var(--ink-danger);
 }
 .ink-alert__content {
   flex: 1;

--- a/src/styles/themes/kaleido.css
+++ b/src/styles/themes/kaleido.css
@@ -1,0 +1,23 @@
+/* EPaper · Kaleido color panel theme
+ * Color is an additional status cue only. Components retain their icon,
+ * border-weight and hatch encodings so every state still survives 1-bit
+ * rendering. Apply with data-ink-theme="kaleido" or .ink-theme--kaleido. */
+
+[data-ink-theme='kaleido'],
+.ink-theme--kaleido {
+  color-scheme: light;
+  --ink-fg: #000;
+  --ink-bg: #fff;
+  --ink-fg-inverted: #fff;
+  --ink-bg-inverted: #000;
+  --ink-accent: var(--kaleido-blue);
+  --ink-info: var(--kaleido-blue);
+  --ink-success: var(--kaleido-green);
+  --ink-warning: var(--kaleido-orange);
+  --ink-danger: var(--kaleido-red);
+  --ink-hatch-error: repeating-linear-gradient(
+    45deg,
+    var(--kaleido-red) 0 2px,
+    transparent 2px 6px
+  );
+}

--- a/src/styles/themes/mono-high-contrast.css
+++ b/src/styles/themes/mono-high-contrast.css
@@ -1,0 +1,30 @@
+/* EPaper · High-contrast monochrome panel theme
+ * Import after tokens.css, then apply data-ink-theme="mono-high-contrast" to
+ * an ancestor (usually <html>) or add .ink-theme--mono-high-contrast to a
+ * scoped container. */
+
+[data-ink-theme='mono-high-contrast'],
+.ink-theme--mono-high-contrast {
+  color-scheme: light;
+  --ink-fg: #000;
+  --ink-bg: #fff;
+  --ink-fg-inverted: #fff;
+  --ink-bg-inverted: #000;
+  --ink-accent: #000;
+  --ink-info: #000;
+  --ink-success: #000;
+  --ink-warning: #000;
+  --ink-danger: #000;
+  --ink-border-width: 3px;
+  --ink-border-width-strong: 5px;
+  --ink-border-width-hair: 2px;
+  --ink-border-width-error: 4px;
+  --ink-focus-width: 4px;
+  --ink-focus-offset: 3px;
+  --ink-control-h-sm: 40px;
+  --ink-control-h-md: 48px;
+  --ink-control-h-lg: 52px;
+  --ink-hatch-disabled: repeating-linear-gradient(45deg, #000 0 2px, transparent 2px 5px);
+  --ink-hatch-error: repeating-linear-gradient(135deg, #000 0 2px, transparent 2px 6px);
+  --ink-hatch-cover: repeating-linear-gradient(45deg, #fff 0 2px, #000 2px 5px);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -39,6 +39,14 @@
   --ink-fg-inverted: #fff;
   --ink-bg-inverted: #000;
 
+  /* Semantic colors collapse to monochrome by default. Panel themes may
+     replace them, while component shape/icon/hatch cues remain intact. */
+  --ink-accent: var(--ink-fg);
+  --ink-info: var(--ink-fg);
+  --ink-success: var(--ink-fg);
+  --ink-warning: var(--ink-fg);
+  --ink-danger: var(--ink-fg);
+
   /* Kaleido — only ever as flat fills, reserved for state */
   --kaleido-red: #d11a1a;
   --kaleido-orange: #e26a1b;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 import { resolve } from 'node:path';
 
+const playwrightExecutable = process.env['PLAYWRIGHT_EXECUTABLE_PATH'];
+const browserProvider = () =>
+  playwright(
+    playwrightExecutable ? { launchOptions: { executablePath: playwrightExecutable } } : {},
+  );
+
 export default defineConfig({
   test: {
     projects: [
@@ -13,7 +19,7 @@ export default defineConfig({
           browser: {
             enabled: true,
             headless: true,
-            provider: playwright(),
+            provider: browserProvider(),
             instances: [{ browser: 'chromium' }],
             expect: {
               toMatchScreenshot: {
@@ -46,7 +52,7 @@ export default defineConfig({
           browser: {
             enabled: true,
             headless: true,
-            provider: playwright(),
+            provider: browserProvider(),
             instances: [{ browser: 'chromium' }],
           },
         },


### PR DESCRIPTION
## Summary

- unify native constraint validation across all 13 form-associated controls
- ship monochrome high-contrast and Kaleido panel theme packs with package exports
- add automated mutation, churn, identity-retention, and dirty-area refresh budgets
- clean the file-based roadmap and document component availability in API docs and Storybook

## Why

This turns the V1.1 roadmap items into testable reliability and panel-specific capabilities. Validation is now consistent across the form controls, and representative e-paper interactions have enforceable refresh budgets.

## Review fixes

- repaired malformed Storybook version descriptions introduced by the bulk availability update
- restored accidentally suffixed Storybook control and icon values
- verified that no generated build, screenshot, or temporary artifacts are included

## Impact

- existing validation behavior is preserved where valid values were already accepted
- invalid native input values now participate consistently in form validity and submission
- theme packs are opt-in through exported CSS entry points
- refresh budgets run as a dedicated test command and remain part of the browser test suite

## Checks

- `npm run type-check`
- `npm run lint:check`
- `npm run format:check`
- `npm run build`
- `npm run build-storybook`
- `npm run size`
- `npm pack --dry-run --json --cache /private/tmp/epaper-components-npm-cache`
- browser suite excluding platform-specific screenshots: 525 tests across 75 files
- targeted validation, theme, and refresh suite: 59 tests

The visual screenshot suite was not included in the local pass because the repository currently carries Linux baselines; CI can exercise the matching platform baselines.
