### PR TITLE
fix: rebase SonarCloud security/quality fixes on main and close the coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Prettier check
         run: npm run format:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       # The landing site deep-links into the deployed Storybook, so it needs
       # the public base URL at build time rather than the localhost default.
@@ -79,7 +79,7 @@ jobs:
           cp -r storybook-static/. site/storybook/
 
       - name: Sync to FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65 # v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -213,7 +213,7 @@ jobs:
           cd "$RUNNER_TEMP/smoke"
           npm init -y >/dev/null
           npm pkg set type=module >/dev/null
-          npm install "@marcomattes/epaper-components@$VERSION" jsdom --silent
+          npm install "@marcomattes/epaper-components@$VERSION" jsdom@30.0.1 --save-exact --ignore-scripts --silent
 
       - name: Run smoke test
         run: |
@@ -259,7 +259,8 @@ jobs:
       github.repository == 'marcomattes/epaper-components' &&
       (github.event_name == 'workflow_dispatch' ||
         (github.event.workflow_run.conclusion == 'success' &&
-         github.event.workflow_run.event == 'push'))
+         github.event.workflow_run.event == 'push' &&
+         github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -291,7 +292,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Compute dev version
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - `npm run bump-version` no longer creates the tag when run off `main`, since
   `main` requires a pull request and a squash or rebase merge would strand a
   tag created on the branch. It prints the post-merge tagging steps instead.
+- The build and release tooling no longer reaches a shell. `scripts/bump-version.mjs`
+  and `scripts/gen-*.mjs` run through `scripts/lib/run-command.mjs`, which
+  resolves an allowlisted executable and spawns it with an argv array, so no
+  interpolated value — version argument, `package.json` version or branch name
+  — can be interpreted as a command. Every `npm ci`/`npm install` step in CI
+  passes `--ignore-scripts`, third-party actions are pinned to commit SHAs, and
+  the `workflow_run` dev-publish job checks the head repository before running.
+- `<e-card>` and `<e-card-image>` share one `syncEyebrowTitle()` helper in
+  `src/core/dom.ts` instead of duplicating the eyebrow/title reconciliation.
+  Rendered output is unchanged.
 
 ### Fixed
 

--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -43,7 +43,7 @@ function localDefinePlugin() {
         const mod = customElementsManifest.modules.find((m) => m.path === modulePath);
         if (!mod) continue;
         mod.exports = mod.exports ?? [];
-        const already = mod.exports.find(
+        const already = mod.exports.some(
           (e) => e.kind === 'custom-element-definition' && e.name === tag,
         );
         if (already) continue;

--- a/sample-app/fixtures/barrel.html
+++ b/sample-app/fixtures/barrel.html
@@ -12,7 +12,7 @@
       }
     </style>
     <script type="module">
-      import '/dist/index.js';
+      import '../../dist/index.js';
     </script>
   </head>
   <body class="ink-page">

--- a/sample-app/fixtures/barrel.html
+++ b/sample-app/fixtures/barrel.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Barrel registration fixture</title>
-    <link rel="stylesheet" href="/dist/styles/epaper.min.css" />
+    <link rel="stylesheet" href="../../dist/styles/epaper.min.css" />
     <style>
       /* Token-override check: this ID's foreground should flow through every
          component painted with --ink-fg underneath it. */

--- a/sample-app/fixtures/compound.html
+++ b/sample-app/fixtures/compound.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Compound registration fixture</title>
-    <link rel="stylesheet" href="/dist/styles/epaper.min.css" />
+    <link rel="stylesheet" href="../../dist/styles/epaper.min.css" />
     <script type="module">
       import '../../dist/components/select.js';
     </script>

--- a/sample-app/fixtures/compound.html
+++ b/sample-app/fixtures/compound.html
@@ -5,7 +5,7 @@
     <title>Compound registration fixture</title>
     <link rel="stylesheet" href="/dist/styles/epaper.min.css" />
     <script type="module">
-      import '/dist/components/select.js';
+      import '../../dist/components/select.js';
     </script>
   </head>
   <body class="ink-page">

--- a/sample-app/fixtures/selective.html
+++ b/sample-app/fixtures/selective.html
@@ -5,7 +5,7 @@
     <title>Selective registration fixture</title>
     <link rel="stylesheet" href="/dist/styles/epaper.min.css" />
     <script type="module">
-      import '/dist/components/button.js';
+      import '../../dist/components/button.js';
     </script>
   </head>
   <body class="ink-page">

--- a/sample-app/fixtures/selective.html
+++ b/sample-app/fixtures/selective.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Selective registration fixture</title>
-    <link rel="stylesheet" href="/dist/styles/epaper.min.css" />
+    <link rel="stylesheet" href="../../dist/styles/epaper.min.css" />
     <script type="module">
       import '../../dist/components/button.js';
     </script>

--- a/sample-app/validate.mjs
+++ b/sample-app/validate.mjs
@@ -26,7 +26,8 @@ const results = [];
 function record(name, pass, detail) {
   results.push({ name, pass, detail });
   const mark = pass ? 'PASS' : 'FAIL';
-  console.log(`[${mark}] ${name}${detail ? ` — ${detail}` : ''}`);
+  const detailSuffix = detail ? ` — ${detail}` : '';
+  console.log(`[${mark}] ${name}${detailSuffix}`);
 }
 function assert(name, condition, detail) {
   record(name, !!condition, detail);
@@ -429,6 +430,9 @@ console.log('');
 console.log(`${results.length - failed.length}/${results.length} checks passed.`);
 if (failed.length) {
   console.log('Failed:');
-  for (const f of failed) console.log(`  - ${f.name}${f.detail ? ` (${f.detail})` : ''}`);
+  for (const f of failed) {
+    const detailSuffix = f.detail ? ` (${f.detail})` : '';
+    console.log(`  - ${f.name}${detailSuffix}`);
+  }
   process.exit(1);
 }

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -91,7 +91,9 @@ async function buildCSS() {
   console.log('  - dist/styles/epaper.min.css (+.map)');
 }
 
-buildCSS().catch((err) => {
+try {
+  await buildCSS();
+} catch (err) {
   console.error('Error building CSS:', err);
   process.exit(1);
-});
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -11,7 +11,7 @@ if (!input) {
 }
 
 const allowedRanges = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
-const VERSION_ARG_RE = /^v?\d+\.\d+\.\d+(?:[-+][\w.-]*)?$/;
+const VERSION_ARG_RE = /^v?\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
 const isExactVersion = VERSION_ARG_RE.test(input);
 if (!allowedRanges.includes(input) && !isExactVersion) {
   console.error(`Invalid version argument: ${input}`);
@@ -26,7 +26,7 @@ if (!allowedRanges.includes(input) && !isExactVersion) {
 runCommand('npm', ['version', input, '--no-git-tag-version']);
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
 if (typeof pkg.version !== 'string' || !SEMVER_RE.test(pkg.version)) {
   console.error(`package.json version is not a valid semver string: ${pkg.version}`);
   process.exit(1);

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
 
@@ -20,34 +20,34 @@ if (!allowedRanges.includes(input) && !isExactVersion) {
   process.exit(1);
 }
 
-function run(command) {
-  execSync(command, { stdio: 'inherit' });
+function run(command, args) {
+  execFileSync(command, args, { stdio: 'inherit' });
 }
 
-function capture(command) {
-  return execSync(command, { encoding: 'utf8' }).trim();
+function capture(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' }).trim();
 }
 
-run(`npm version ${input} --no-git-tag-version`);
+run('npm', ['version', input, '--no-git-tag-version']);
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const version = pkg.version;
 const commitMessage = `chore(release): bump version to v${version}`;
 
-run('npm run build');
-run('git add --all');
-run(`git commit -m "${commitMessage}"`);
+run('npm', ['run', 'build']);
+run('git', ['add', '--all']);
+run('git', ['commit', '-m', commitMessage]);
 
 // `main` is protected by a ruleset that requires a pull request, so the bump
 // lands through a PR. Tagging here would be wrong: a squash or rebase merge
 // rewrites this commit, and the tag would point at an object that never
 // reaches `main`. On a release branch the tag is therefore left to the
 // maintainer, after the merge.
-const branch = capture('git rev-parse --abbrev-ref HEAD');
+const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
 const defaultBranch = 'main';
 
 if (branch === defaultBranch) {
-  run(`git tag -a v${version} -m "Release v${version}"`);
+  run('git', ['tag', '-a', `v${version}`, '-m', `Release v${version}`]);
   console.log(`\n✅ Bumped to v${version}, committed and tagged.`);
   console.log('   Push with: git push --follow-tags');
 } else {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -11,7 +11,8 @@ if (!input) {
 }
 
 const allowedRanges = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
-const isExactVersion = /^v?\d+\.\d+\.\d+(?:[-+].*)?$/.test(input);
+const VERSION_ARG_RE = /^v?\d+\.\d+\.\d+(?:[-+][\w.-]*)?$/;
+const isExactVersion = VERSION_ARG_RE.test(input);
 if (!allowedRanges.includes(input) && !isExactVersion) {
   console.error(`Invalid version argument: ${input}`);
   console.error(
@@ -20,54 +21,42 @@ if (!allowedRanges.includes(input) && !isExactVersion) {
   process.exit(1);
 }
 
-function run(command, args) {
-  execFileSync(command, args, { stdio: 'inherit' });
-}
-
-function capture(command, args) {
-  return execFileSync(command, args, { encoding: 'utf8' }).trim();
-}
-
-/** Validate a dynamic argument against an allowlist pattern before it reaches execFileSync. */
-function assertSafeArg(value, pattern, label) {
-  if (!pattern.test(value)) {
-    console.error(`Refusing to run: ${label} "${value}" failed validation.`);
-    process.exit(1);
-  }
-  return value;
-}
-
-const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
-const BRANCH_RE = /^[\w./-]+$/;
-
-run('npm', [
-  'version',
-  assertSafeArg(input, /^[\w.+-]+$/, 'version argument'),
-  '--no-git-tag-version',
-]);
+// `input` is now provably one of `allowedRanges` or matches VERSION_ARG_RE — it is
+// never passed to execFileSync unchecked beyond this point.
+execFileSync('npm', ['version', input, '--no-git-tag-version'], { stdio: 'inherit' });
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-const version = assertSafeArg(pkg.version, SEMVER_RE, 'package.json version');
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+if (typeof pkg.version !== 'string' || !SEMVER_RE.test(pkg.version)) {
+  console.error(`package.json version is not a valid semver string: ${pkg.version}`);
+  process.exit(1);
+}
+const version = pkg.version;
 const commitMessage = `chore(release): bump version to v${version}`;
 
-run('npm', ['run', 'build']);
-run('git', ['add', '--all']);
-run('git', ['commit', '-m', commitMessage]);
+execFileSync('npm', ['run', 'build'], { stdio: 'inherit' });
+execFileSync('git', ['add', '--all'], { stdio: 'inherit' });
+execFileSync('git', ['commit', '-m', commitMessage], { stdio: 'inherit' });
 
 // `main` is protected by a ruleset that requires a pull request, so the bump
 // lands through a PR. Tagging here would be wrong: a squash or rebase merge
 // rewrites this commit, and the tag would point at an object that never
 // reaches `main`. On a release branch the tag is therefore left to the
 // maintainer, after the merge.
-const branch = assertSafeArg(
-  capture('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
-  BRANCH_RE,
-  'current branch name',
-);
+const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+  encoding: 'utf8',
+}).trim();
+const BRANCH_RE = /^[\w./-]+$/;
+if (!BRANCH_RE.test(branch)) {
+  console.error(`Unexpected characters in current branch name: ${branch}`);
+  process.exit(1);
+}
 const defaultBranch = 'main';
 
 if (branch === defaultBranch) {
-  run('git', ['tag', '-a', `v${version}`, '-m', `Release v${version}`]);
+  execFileSync('git', ['tag', '-a', `v${version}`, '-m', `Release v${version}`], {
+    stdio: 'inherit',
+  });
   console.log(`\n✅ Bumped to v${version}, committed and tagged.`);
   console.log('   Push with: git push --follow-tags');
 } else {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -28,10 +28,26 @@ function capture(command, args) {
   return execFileSync(command, args, { encoding: 'utf8' }).trim();
 }
 
-run('npm', ['version', input, '--no-git-tag-version']);
+/** Validate a dynamic argument against an allowlist pattern before it reaches execFileSync. */
+function assertSafeArg(value, pattern, label) {
+  if (!pattern.test(value)) {
+    console.error(`Refusing to run: ${label} "${value}" failed validation.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+const BRANCH_RE = /^[\w./-]+$/;
+
+run('npm', [
+  'version',
+  assertSafeArg(input, /^[\w.+-]+$/, 'version argument'),
+  '--no-git-tag-version',
+]);
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-const version = pkg.version;
+const version = assertSafeArg(pkg.version, SEMVER_RE, 'package.json version');
 const commitMessage = `chore(release): bump version to v${version}`;
 
 run('npm', ['run', 'build']);
@@ -43,7 +59,11 @@ run('git', ['commit', '-m', commitMessage]);
 // rewrites this commit, and the tag would point at an object that never
 // reaches `main`. On a release branch the tag is therefore left to the
 // maintainer, after the merge.
-const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+const branch = assertSafeArg(
+  capture('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+  BRANCH_RE,
+  'current branch name',
+);
 const defaultBranch = 'main';
 
 if (branch === defaultBranch) {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,6 +1,6 @@
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
+import { runCommand, captureCommand } from './lib/run-command.mjs';
 
 const input = process.argv[2];
 if (!input) {
@@ -22,8 +22,8 @@ if (!allowedRanges.includes(input) && !isExactVersion) {
 }
 
 // `input` is now provably one of `allowedRanges` or matches VERSION_ARG_RE — it is
-// never passed to execFileSync unchecked beyond this point.
-execFileSync('npm', ['version', input, '--no-git-tag-version'], { stdio: 'inherit' });
+// never passed to runCommand unchecked beyond this point.
+runCommand('npm', ['version', input, '--no-git-tag-version']);
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
@@ -34,18 +34,16 @@ if (typeof pkg.version !== 'string' || !SEMVER_RE.test(pkg.version)) {
 const version = pkg.version;
 const commitMessage = `chore(release): bump version to v${version}`;
 
-execFileSync('npm', ['run', 'build'], { stdio: 'inherit' });
-execFileSync('git', ['add', '--all'], { stdio: 'inherit' });
-execFileSync('git', ['commit', '-m', commitMessage], { stdio: 'inherit' });
+runCommand('npm', ['run', 'build']);
+runCommand('git', ['add', '--all']);
+runCommand('git', ['commit', '-m', commitMessage]);
 
 // `main` is protected by a ruleset that requires a pull request, so the bump
 // lands through a PR. Tagging here would be wrong: a squash or rebase merge
 // rewrites this commit, and the tag would point at an object that never
 // reaches `main`. On a release branch the tag is therefore left to the
 // maintainer, after the merge.
-const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-  encoding: 'utf8',
-}).trim();
+const branch = captureCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
 const BRANCH_RE = /^[\w./-]+$/;
 if (!BRANCH_RE.test(branch)) {
   console.error(`Unexpected characters in current branch name: ${branch}`);
@@ -54,9 +52,7 @@ if (!BRANCH_RE.test(branch)) {
 const defaultBranch = 'main';
 
 if (branch === defaultBranch) {
-  execFileSync('git', ['tag', '-a', `v${version}`, '-m', `Release v${version}`], {
-    stdio: 'inherit',
-  });
+  runCommand('git', ['tag', '-a', `v${version}`, '-m', `Release v${version}`]);
   console.log(`\n✅ Bumped to v${version}, committed and tagged.`);
   console.log('   Push with: git push --follow-tags');
 } else {

--- a/scripts/gen-pages-index.mjs
+++ b/scripts/gen-pages-index.mjs
@@ -3,9 +3,15 @@
 // Env:   BASE_URL (e.g. "/epaper-components/")
 
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 
-const out = process.argv[2] ?? '_site/index.html';
+const outArg = process.argv[2] ?? '_site/index.html';
+const outRoot = resolve(process.cwd());
+const out = resolve(outRoot, outArg);
+if (out !== outRoot && !out.startsWith(outRoot + sep)) {
+  console.error(`[gen-pages-index] refusing to write outside ${outRoot}: ${out}`);
+  process.exit(1);
+}
 const base = (process.env.BASE_URL ?? '/').replace(/\/?$/, '/');
 
 const pkg = JSON.parse(readFileSync(resolve('package.json'), 'utf8'));

--- a/scripts/gen-readmes.mjs
+++ b/scripts/gen-readmes.mjs
@@ -41,7 +41,7 @@ const screenshotFiles = existsSync(screenshotsDir)
  * Screenshot   `inputs-inputnumber--default.png` → middle `inputnumber`
  */
 function findScreenshot(basenameNoExt) {
-  const key = basenameNoExt.replace(/-/g, '');
+  const key = basenameNoExt.replaceAll(/-/g, '');
   for (const f of screenshotFiles) {
     const m = f.match(/^[a-z0-9]+-([a-z0-9]+)--/);
     if (m && m[1] === key) return f;
@@ -50,7 +50,9 @@ function findScreenshot(basenameNoExt) {
 }
 
 function escMd(s) {
-  return String(s).replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+  return String(s)
+    .replaceAll(/\|/g, String.raw`\|`)
+    .replaceAll(/\r?\n/g, ' ');
 }
 
 function attrsTable(attrs) {

--- a/scripts/gen-tag-map.mjs
+++ b/scripts/gen-tag-map.mjs
@@ -55,7 +55,17 @@ for (const e of entries) {
 
 // Simpler & more robust: import everything from the package's own type entry.
 // Since this file lives in dist/elements.d.ts, sibling import is "./index.js".
-const classNames = [...new Set(entries.map((e) => e.className))].sort((a, b) => a.localeCompare(b));
+// Explicit code-unit comparator rather than `localeCompare`: this ordering ends
+// up in the shipped `dist/elements.d.ts`, and `localeCompare` resolves against
+// the runtime's default locale and ICU data, so the same source would generate
+// a different file on a differently-configured Node (e.g. a `small-icu` build).
+// Code-unit order keeps the build reproducible while still passing an explicit
+// compare function.
+const byCodeUnit = (a, b) => {
+  if (a < b) return -1;
+  return a > b ? 1 : 0;
+};
+const classNames = [...new Set(entries.map((e) => e.className))].sort(byCodeUnit);
 const importLine = `import type { ${classNames.join(', ')} } from './index.js';`;
 
 const mapLines = entries

--- a/scripts/gen-tag-map.mjs
+++ b/scripts/gen-tag-map.mjs
@@ -55,7 +55,7 @@ for (const e of entries) {
 
 // Simpler & more robust: import everything from the package's own type entry.
 // Since this file lives in dist/elements.d.ts, sibling import is "./index.js".
-const classNames = [...new Set(entries.map((e) => e.className))].sort();
+const classNames = [...new Set(entries.map((e) => e.className))].sort((a, b) => a.localeCompare(b));
 const importLine = `import type { ${classNames.join(', ')} } from './index.js';`;
 
 const mapLines = entries

--- a/scripts/inline-site-css.mjs
+++ b/scripts/inline-site-css.mjs
@@ -11,10 +11,8 @@ const assetsDir = join(distDir, 'assets');
 
 // Mirrors `base` in vite.site.config.ts. Normalised to a single leading and
 // trailing slash so the rewritten chunk URLs resolve from any page depth.
-const siteBase = `/${(process.env.VITE_SITE_BASE || '/').replace(/^\/+|\/+$/g, '')}/`.replace(
-  '//',
-  '/',
-);
+const trimmedSiteBase = (process.env.VITE_SITE_BASE || '/').replace(/^\/+/, '').replace(/\/+$/, '');
+const siteBase = `/${trimmedSiteBase}/`.replace('//', '/');
 const assetPrefix = `${siteBase}assets/`;
 
 const html = await readFile(htmlPath, 'utf8');

--- a/scripts/lib/run-command.mjs
+++ b/scripts/lib/run-command.mjs
@@ -1,0 +1,54 @@
+// Sole entry point for OS command execution used by scripts/*.mjs. Kept in
+// its own module, deliberately independent of process.argv/CLI input, so the
+// command allowlist below is the only thing standing between a caller and an
+// actual spawned process.
+import { execFileSync } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import process from 'node:process';
+
+const ALLOWED_COMMANDS = new Set(['npm', 'git']);
+
+// Resolve each allowed command to an absolute path ourselves — rather than
+// pass the bare name to execFileSync and let the OS walk PATH implicitly —
+// so the executable actually invoked is fixed and auditable up front.
+const resolvedPathCache = new Map();
+
+function resolveExecutable(name) {
+  const cached = resolvedPathCache.get(name);
+  if (cached) return cached;
+
+  const candidateExts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : [''];
+  const dirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const ext of candidateExts) {
+      const candidate = join(dir, name + ext);
+      try {
+        accessSync(candidate, constants.X_OK);
+        resolvedPathCache.set(name, candidate);
+        return candidate;
+      } catch {
+        /* not found in this directory, keep looking */
+      }
+    }
+  }
+  throw new Error(`run-command: could not resolve "${name}" to an executable on PATH.`);
+}
+
+function assertAllowed(command) {
+  if (!ALLOWED_COMMANDS.has(command)) {
+    throw new Error(`run-command: "${command}" is not an allowed command.`);
+  }
+}
+
+/** Run an allowlisted command with argv-array arguments (never through a shell), inheriting stdio. */
+export function runCommand(command, args) {
+  assertAllowed(command);
+  execFileSync(resolveExecutable(command), args, { stdio: 'inherit' });
+}
+
+/** Same as runCommand, but captures and returns trimmed stdout instead of inheriting it. */
+export function captureCommand(command, args) {
+  assertAllowed(command);
+  return execFileSync(resolveExecutable(command), args, { encoding: 'utf8' }).trim();
+}

--- a/scripts/lib/run-command.mjs
+++ b/scripts/lib/run-command.mjs
@@ -3,7 +3,7 @@
 // command allowlist below is the only thing standing between a caller and an
 // actual spawned process.
 import { execFileSync } from 'node:child_process';
-import { accessSync, constants } from 'node:fs';
+import { accessSync, constants, statSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 import process from 'node:process';
 
@@ -24,7 +24,12 @@ function resolveExecutable(name) {
     for (const ext of candidateExts) {
       const candidate = join(dir, name + ext);
       try {
+        // accessSync(X_OK) alone also succeeds for a directory (the execute
+        // bit means "traversable" there) — require a regular file too, or a
+        // directory named "npm"/"git" on PATH would be cached and then fail
+        // at spawn time with a confusing EACCES.
         accessSync(candidate, constants.X_OK);
+        if (!statSync(candidate).isFile()) continue;
         resolvedPathCache.set(name, candidate);
         return candidate;
       } catch {

--- a/scripts/site-template.mjs
+++ b/scripts/site-template.mjs
@@ -20,7 +20,7 @@ const SLOTS = /** @type {const} */ (['head', 'main', 'nav', 'pagenav']);
 export function applyRouteBlocks(html, blocks) {
   let out = html;
   for (const slot of SLOTS) {
-    const re = new RegExp(`<!--site:${slot}-->[\\s\\S]*?<!--/site:${slot}-->`);
+    const re = new RegExp(String.raw`<!--site:${slot}-->[\s\S]*?<!--/site:${slot}-->`);
     if (!re.test(out)) {
       throw new Error(`site-template: slot "${slot}" not found — did the shell markers change?`);
     }

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -46,9 +46,15 @@ for (const key of globals) {
 
 // Not implemented by jsdom; a few components observe size or visibility.
 class NoopObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe() {
+    // Intentionally a no-op: jsdom has no layout engine to observe.
+  }
+  unobserve() {
+    // Intentionally a no-op: jsdom has no layout engine to observe.
+  }
+  disconnect() {
+    // Intentionally a no-op: jsdom has no layout engine to observe.
+  }
 }
 globalThis.ResizeObserver ??= NoopObserver;
 globalThis.IntersectionObserver ??= NoopObserver;

--- a/src/components/__tests__/cleanup.test.ts
+++ b/src/components/__tests__/cleanup.test.ts
@@ -391,7 +391,12 @@ describe('global listener cleanup', () => {
     }
   });
 
-  it('e-cascader removes its document listener on disconnect', () => {
+  it.each([
+    { tag: 'e-cascader', attr: 'options', value: '[{"value":"a","label":"A"}]' },
+    { tag: 'e-date-picker', attr: 'value', value: '2026-04-26' },
+    { tag: 'e-popover', attr: 'heading', value: 'Status' },
+    { tag: 'e-popconfirm', attr: 'message', value: 'Sure?' },
+  ])('$tag removes its document listener(s) on disconnect', ({ tag, attr, value }) => {
     let added = 0;
     let removed = 0;
     const origAdd = document.addEventListener;
@@ -406,34 +411,8 @@ describe('global listener cleanup', () => {
     };
 
     try {
-      const el = document.createElement('e-cascader');
-      el.setAttribute('options', '[{"value":"a","label":"A"}]');
-      document.body.appendChild(el);
-      el.remove();
-      expect(added - removed).toBe(0);
-    } finally {
-      document.addEventListener = origAdd;
-      document.removeEventListener = origRemove;
-    }
-  });
-
-  it('e-date-picker removes its document listener on disconnect', () => {
-    let added = 0;
-    let removed = 0;
-    const origAdd = document.addEventListener;
-    const origRemove = document.removeEventListener;
-    document.addEventListener = function (...args: Parameters<typeof origAdd>) {
-      added++;
-      return origAdd.apply(this, args);
-    };
-    document.removeEventListener = function (...args: Parameters<typeof origRemove>) {
-      removed++;
-      return origRemove.apply(this, args);
-    };
-
-    try {
-      const el = document.createElement('e-date-picker');
-      el.setAttribute('value', '2026-04-26');
+      const el = document.createElement(tag);
+      el.setAttribute(attr, value);
       document.body.appendChild(el);
       el.remove();
       expect(added - removed).toBe(0);
@@ -458,58 +437,6 @@ describe('global listener cleanup', () => {
     el.remove();
     el.removeEventListener = origRemove;
     expect(removed).toBeGreaterThanOrEqual(1);
-  });
-
-  it('e-popover removes its document listeners on disconnect', () => {
-    let added = 0;
-    let removed = 0;
-    const origAdd = document.addEventListener;
-    const origRemove = document.removeEventListener;
-    document.addEventListener = function (...args: Parameters<typeof origAdd>) {
-      added++;
-      return origAdd.apply(this, args);
-    };
-    document.removeEventListener = function (...args: Parameters<typeof origRemove>) {
-      removed++;
-      return origRemove.apply(this, args);
-    };
-
-    try {
-      const el = document.createElement('e-popover');
-      el.setAttribute('heading', 'Status');
-      document.body.appendChild(el);
-      el.remove();
-      expect(added - removed).toBe(0);
-    } finally {
-      document.addEventListener = origAdd;
-      document.removeEventListener = origRemove;
-    }
-  });
-
-  it('e-popconfirm removes its document listeners on disconnect', () => {
-    let added = 0;
-    let removed = 0;
-    const origAdd = document.addEventListener;
-    const origRemove = document.removeEventListener;
-    document.addEventListener = function (...args: Parameters<typeof origAdd>) {
-      added++;
-      return origAdd.apply(this, args);
-    };
-    document.removeEventListener = function (...args: Parameters<typeof origRemove>) {
-      removed++;
-      return origRemove.apply(this, args);
-    };
-
-    try {
-      const el = document.createElement('e-popconfirm');
-      el.setAttribute('message', 'Sure?');
-      document.body.appendChild(el);
-      el.remove();
-      expect(added - removed).toBe(0);
-    } finally {
-      document.addEventListener = origAdd;
-      document.removeEventListener = origRemove;
-    }
   });
 
   it('e-dialog cleans up its native listeners and restores page scroll', () => {

--- a/src/components/__tests__/data-display.test.ts
+++ b/src/components/__tests__/data-display.test.ts
@@ -138,7 +138,7 @@ describe('e-skeleton', () => {
 
   it('renders N text lines when shape="text"', () => {
     const el = mount(`<e-skeleton shape="text" lines="4"></e-skeleton>`);
-    expect(el.querySelectorAll('.ink-skeleton__line').length).toBe(4);
+    expect(el.querySelectorAll('.ink-skeleton__line')).toHaveLength(4);
   });
 
   it('renders a circle variant', () => {
@@ -171,8 +171,8 @@ describe('e-progress', () => {
   it('steps variant renders N segments and fills the right amount', () => {
     const el = mount(`<e-progress value="3" max="5" variant="steps" steps="5"></e-progress>`);
     const segs = el.querySelectorAll('.ink-progress__seg');
-    expect(segs.length).toBe(5);
-    expect(el.querySelectorAll('.ink-progress__seg[data-on]').length).toBe(3);
+    expect(segs).toHaveLength(5);
+    expect(el.querySelectorAll('.ink-progress__seg[data-on]')).toHaveLength(3);
   });
 
   it('clamps value to max in aria and fill', () => {
@@ -239,7 +239,7 @@ describe('e-list', () => {
       </e-list>`,
     );
     const items = el.querySelectorAll('e-list-item');
-    expect(items.length).toBe(2);
+    expect(items).toHaveLength(2);
     expect(items[0].getAttribute('role')).toBe('listitem');
     expect(el.querySelector('.ink-list')!.getAttribute('role')).toBe('list');
   });
@@ -295,7 +295,7 @@ describe('e-table', () => {
   it('renders a header with the given columns', () => {
     const el = mount(`<e-table columns='${COLS}' data='${ROWS}'></e-table>`);
     const ths = el.querySelectorAll('thead th');
-    expect(ths.length).toBe(2);
+    expect(ths).toHaveLength(2);
     expect(ths[0].textContent).toContain('Name');
     expect(ths[1].textContent).toContain('Role');
   });
@@ -303,7 +303,7 @@ describe('e-table', () => {
   it('renders one row per data entry, with cells in column order', () => {
     const el = mount(`<e-table columns='${COLS}' data='${ROWS}'></e-table>`);
     const rows = el.querySelectorAll('tbody tr');
-    expect(rows.length).toBe(3);
+    expect(rows).toHaveLength(3);
     const firstCells = rows[0].querySelectorAll('td');
     expect(firstCells[0].textContent).toBe('Anna');
     expect(firstCells[1].textContent).toBe('Editor');
@@ -488,7 +488,7 @@ describe('e-collapse', () => {
   it('renders one details per panel and adopts the body', () => {
     const el = mount(markup());
     const panels = el.querySelectorAll('details');
-    expect(panels.length).toBe(2);
+    expect(panels).toHaveLength(2);
     expect(panels[0]!.querySelector('.ink-collapse__heading')!.textContent).toBe('A');
     expect(panels[0]!.querySelector('.ink-collapse__body')!.textContent).toContain('Body A');
   });
@@ -663,7 +663,7 @@ describe('e-tree', () => {
     wrap.appendChild(el);
     expect(detail).not.toBeNull();
     expect(detail!.source).toBe('data');
-    expect(el.querySelectorAll('.ink-tree__row').length).toBe(0);
+    expect(el.querySelectorAll('.ink-tree__row')).toHaveLength(0);
   });
 
   it('keeps exactly one visible tabbable row when a selected child is revealed', () => {
@@ -673,10 +673,10 @@ describe('e-tree', () => {
     const el = mount(`<e-tree selectable data='${DATA}' value="c1"></e-tree>`);
     const tabbable = () =>
       [...el.querySelectorAll<HTMLElement>('.ink-tree__row')].filter((r) => r.tabIndex === 0);
-    expect(tabbable().length).toBe(1);
+    expect(tabbable()).toHaveLength(1);
 
     el.querySelector<HTMLElement>('[data-expand="p"]')!.click();
-    expect(tabbable().length).toBe(1);
+    expect(tabbable()).toHaveLength(1);
     expect(tabbable()[0]!.dataset['value']).toBe('c1');
   });
 
@@ -688,12 +688,12 @@ describe('e-tree', () => {
       );
 
     el.querySelector<HTMLElement>('[data-value="c2"]')!.focus();
-    expect(visibleTabbable().length).toBe(1);
+    expect(visibleTabbable()).toHaveLength(1);
 
     // Collapsing the parent hides the focused row; the stop moves to the parent.
     el.querySelector<HTMLElement>('[data-expand="p"]')!.click();
     const stops = visibleTabbable();
-    expect(stops.length).toBe(1);
+    expect(stops).toHaveLength(1);
     expect(stops[0]!.dataset['value']).toBe('p');
   });
 });

--- a/src/components/__tests__/reactivity.test.ts
+++ b/src/components/__tests__/reactivity.test.ts
@@ -14,6 +14,12 @@ beforeAll(async () => {
   await import('../dialog');
   await import('../tree');
   await import('../popover');
+  await import('../card');
+  await import('../card-image');
+  await import('../avatar');
+  await import('../calendar');
+  await import('../cascader');
+  await import('../date-picker');
 });
 
 // A modal <dialog> makes the rest of the document inert and holds a share of
@@ -356,5 +362,235 @@ describe('events', () => {
 
     el.querySelector<HTMLElement>('[data-action="confirm"] button')!.click();
     expect(document.activeElement).toBe(trigger);
+  });
+});
+
+// The card family shares `syncEyebrowTitle` in core/dom.ts, and the interesting
+// direction is the shrinking one: an attribute going away has to take its
+// element with it instead of leaving a stale heading behind.
+describe('card header teardown', () => {
+  it('e-card drops the title, then the whole header, as the attributes go away', () => {
+    const el = mount<HTMLElement>(`<e-card eyebrow="PROJECT" title="Atlas">Body</e-card>`);
+    expect(el.querySelector('.ink-card__eyebrow')!.textContent).toBe('PROJECT');
+    expect(el.querySelector('.ink-card__title')!.textContent).toBe('Atlas');
+
+    // The eyebrow still needs a header, so only the <h3> goes.
+    el.removeAttribute('title');
+    expect(el.querySelector('.ink-card__title')).toBeNull();
+    expect(el.querySelector('.ink-card__header')).not.toBeNull();
+
+    // Nothing left to head the card with — the header itself goes.
+    el.removeAttribute('eyebrow');
+    expect(el.querySelector('.ink-card__eyebrow')).toBeNull();
+    expect(el.querySelector('.ink-card__header')).toBeNull();
+    expect(el.querySelector('.ink-card__body')!.textContent).toBe('Body');
+
+    // And a later attribute rebuilds it from scratch.
+    el.setAttribute('title', 'Atlas II');
+    expect(el.querySelector('.ink-card__title')!.textContent).toBe('Atlas II');
+  });
+
+  it('e-card keeps an action header after both headings are gone', () => {
+    const el = mount<HTMLElement>(
+      `<e-card eyebrow="PROJECT" title="Atlas"><e-button slot="action">Open</e-button>Body</e-card>`,
+    );
+    const header = el.querySelector<HTMLElement>('.ink-card__header')!;
+
+    // The action slot alone keeps the header alive, so this exercises the
+    // eyebrow and title removals rather than the header teardown.
+    el.removeAttribute('eyebrow');
+    el.removeAttribute('title');
+    expect(el.querySelector('.ink-card__header')).toBe(header);
+    expect(el.querySelector('.ink-card__eyebrow')).toBeNull();
+    expect(el.querySelector('.ink-card__title')).toBeNull();
+    expect(header.querySelector('e-button')).not.toBeNull();
+  });
+
+  it('e-card renders no header at all without headings or an action', () => {
+    const el = mount<HTMLElement>(`<e-card>Body</e-card>`);
+    expect(el.querySelector('.ink-card__header')).toBeNull();
+    expect(el.querySelector('.ink-card__body')!.textContent).toBe('Body');
+
+    // Repeated renders must not conjure one either.
+    el.setAttribute('eyebrow', '');
+    expect(el.querySelector('.ink-card__header')).toBeNull();
+  });
+
+  it('e-card-image drops cover and header without losing the footer', () => {
+    const el = mount<HTMLElement>(
+      `<e-card-image cover="hatch" eyebrow="GUIDE" title="Setup">
+         Body
+         <div slot="footer">Updated today</div>
+       </e-card-image>`,
+    );
+    const footer = el.querySelector<HTMLElement>('.ink-card__footer')!;
+    const cover = el.querySelector<HTMLElement>('.ink-card__cover')!;
+    expect(cover.className).toContain('ink-card__cover--hatch');
+
+    // A plain value keeps the same cover node and renders as its text.
+    el.setAttribute('cover', 'Sunset');
+    expect(el.querySelector('.ink-card__cover')).toBe(cover);
+    expect(cover.className).not.toContain('ink-card__cover--hatch');
+    expect(cover.textContent).toBe('Sunset');
+
+    el.removeAttribute('cover');
+    expect(el.querySelector('.ink-card__cover')).toBeNull();
+
+    el.removeAttribute('title');
+    expect(el.querySelector('.ink-card__title')).toBeNull();
+    el.removeAttribute('eyebrow');
+    expect(el.querySelector('.ink-card__header')).toBeNull();
+
+    // A detached footer is re-attached on the next render rather than rebuilt,
+    // so the slotted content keeps its identity.
+    footer.remove();
+    el.setAttribute('title', 'Setup');
+    expect(el.querySelector('.ink-card__footer')).toBe(footer);
+    expect(footer.textContent).toContain('Updated today');
+  });
+});
+
+describe('grid keyboard navigation', () => {
+  const openGrid = (el: HTMLElement) => {
+    el.querySelector<HTMLButtonElement>('[data-trigger]')!.click();
+    return () => [...el.querySelectorAll<HTMLButtonElement>('.ink-datepicker__cell')];
+  };
+  const press = (key: string) =>
+    document.activeElement!.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+
+  it('e-date-picker Home and End move to the ends of the week row', () => {
+    const el = mount<HTMLElement>(`<e-date-picker value="2026-01-15"></e-date-picker>`);
+    const cells = openGrid(el);
+    const column = () => cells().indexOf(document.activeElement as HTMLButtonElement) % 7;
+    expect(document.activeElement!.getAttribute('data-day')).toBe('15');
+
+    press('Home');
+    expect(column()).toBe(0);
+    const weekStart = document.activeElement!.getAttribute('data-day');
+
+    press('End');
+    expect(column()).toBe(6);
+    expect(document.activeElement!.getAttribute('data-day')).not.toBe(weekStart);
+  });
+
+  it('e-date-picker PageUp and PageDown wrap across the year boundary', () => {
+    const el = mount<HTMLElement>(`<e-date-picker value="2026-01-15"></e-date-picker>`);
+    openGrid(el);
+    const navTitle = el.querySelector<HTMLElement>('.ink-datepicker__nav-title')!;
+    const locale = el.lang || document.documentElement.lang || undefined;
+    const month = (y: number, m: number) =>
+      `${new Date(y, m, 1).toLocaleString(locale, { month: 'long' })} ${y}`;
+    expect(navTitle.textContent).toBe(month(2026, 0));
+
+    // January - 1 month is December of the previous year.
+    press('PageUp');
+    expect(navTitle.textContent).toBe(month(2025, 11));
+
+    // ...and December + 1 month is January of the next.
+    press('PageDown');
+    expect(navTitle.textContent).toBe(month(2026, 0));
+  });
+
+  it('e-date-picker ignores keys with nothing to do', () => {
+    const el = mount<HTMLElement>(`<e-date-picker value="2026-01-15"></e-date-picker>`);
+    const cells = openGrid(el);
+    const navTitle = el.querySelector<HTMLElement>('.ink-datepicker__nav-title')!;
+    const before = navTitle.textContent;
+
+    // A key the grid does not handle leaves focus and the view alone.
+    press('Tab');
+    expect(document.activeElement!.getAttribute('data-day')).toBe('15');
+
+    // Padding cells outside the month are disabled and not part of the grid
+    // ring, so a keydown on one is a no-op rather than a focus move.
+    const padding = cells().find((c) => c.disabled)!;
+    padding.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement!.getAttribute('data-day')).toBe('15');
+    expect(navTitle.textContent).toBe(before);
+
+    // The trigger itself only opens on ArrowDown/Enter/Space.
+    const trigger = el.querySelector<HTMLButtonElement>('[data-trigger]')!;
+    trigger.focus();
+    press('ArrowUp');
+    expect(el.querySelector<HTMLElement>('.ink-datepicker__pop')!.hidden).toBe(false);
+  });
+
+  it('e-cascader Home and End jump to the ends of a column', () => {
+    const el = mount<HTMLElement>(
+      `<e-cascader data='[{"value":"a","label":"A"},{"value":"b","label":"B"},{"value":"c","label":"C"}]'></e-cascader>`,
+    );
+    el.querySelector<HTMLButtonElement>('[data-trigger]')!.click();
+    const items = [...el.querySelectorAll<HTMLElement>('.ink-cascader__item')];
+    items[0].focus();
+
+    press('End');
+    expect(document.activeElement).toBe(items.at(-1));
+
+    press('Home');
+    expect(document.activeElement).toBe(items[0]);
+  });
+});
+
+describe('collection patching', () => {
+  it('e-avatar-group adds, removes and re-counts avatars as max changes', () => {
+    const el = mount<HTMLElement>(
+      `<e-avatar-group max="4">
+         ${['A', 'B', 'C', 'D', 'E'].map((n) => `<e-avatar-item name="${n}"></e-avatar-item>`).join('')}
+       </e-avatar-group>`,
+    );
+    const avatars = () => el.querySelectorAll('.ink-avatar-group > e-avatar');
+    const overflow = () => el.querySelector<HTMLElement>('.ink-avatar-group__overflow');
+    expect(avatars()).toHaveLength(4);
+    expect(overflow()!.textContent).toBe('+1');
+
+    // Room for everyone: the fifth avatar appears and the chip goes away.
+    el.setAttribute('max', '5');
+    expect(avatars()).toHaveLength(5);
+    expect(overflow()).toBeNull();
+
+    // Shrinking pops the excess from the end and brings the chip back.
+    el.setAttribute('max', '2');
+    expect(avatars()).toHaveLength(2);
+    expect(overflow()!.textContent).toBe('+3');
+  });
+
+  it('e-calendar repaints a day when event titles or the overflow count change', () => {
+    const events = (...titles: string[]) =>
+      JSON.stringify(titles.map((title) => ({ date: '2026-04-10', title })));
+    const el = mount<HTMLElement>(
+      `<e-calendar value="2026-04-10" events='${events('Release')}'></e-calendar>`,
+    );
+    const chips = () => [
+      ...el.querySelectorAll<HTMLElement>('[data-day="10"] .ink-calendar__events > *'),
+    ];
+    expect(chips().map((c) => c.textContent)).toEqual(['Release']);
+
+    // Same chip count, different text: the container still has to be repainted.
+    el.setAttribute('events', events('Freeze'));
+    expect(chips().map((c) => c.textContent)).toEqual(['Freeze']);
+
+    // Two shown plus a "+N" chip, then the same three slots with a higher N.
+    el.setAttribute('events', events('Freeze', 'Review', 'Ship'));
+    expect(chips().map((c) => c.textContent)).toEqual(['Freeze', 'Review', '+1']);
+    el.setAttribute('events', events('Freeze', 'Review', 'Ship', 'Retro'));
+    expect(chips().map((c) => c.textContent)).toEqual(['Freeze', 'Review', '+2']);
+  });
+
+  it('e-calendar leaves an untouched day alone when a neighbour changes', () => {
+    const el = mount<HTMLElement>(
+      `<e-calendar value="2026-04-10" events='[{"date":"2026-04-10","title":"Release"}]'></e-calendar>`,
+    );
+    const chip = el.querySelector<HTMLElement>('[data-day="10"] .ink-calendar__event')!;
+
+    el.setAttribute(
+      'events',
+      JSON.stringify([
+        { date: '2026-04-10', title: 'Release' },
+        { date: '2026-04-11', title: 'Retro' },
+      ]),
+    );
+    // Same title, same count — the chip is not rebuilt, so the node survives.
+    expect(el.querySelector('[data-day="10"] .ink-calendar__event')).toBe(chip);
+    expect(el.querySelector('[data-day="11"] .ink-calendar__event')!.textContent).toBe('Retro');
   });
 });

--- a/src/components/affix.ts
+++ b/src/components/affix.ts
@@ -21,7 +21,7 @@ import { define, numAttr } from '../core/dom';
  * </e-affix>
  */
 export class EAffix extends HTMLElement {
-  static observedAttributes = ['offset-top'];
+  static readonly observedAttributes = ['offset-top'];
 
   private _wired = false;
   private _wrap: HTMLElement | null = null;

--- a/src/components/alert.ts
+++ b/src/components/alert.ts
@@ -48,7 +48,7 @@ const roleFor = (variant: Variant): string => (variant === 'error' ? 'alert' : '
  * </e-alert>
  */
 export class EAlert extends HTMLElement {
-  static observedAttributes = ['variant', 'heading', 'closable', 'no-icon'];
+  static readonly observedAttributes = ['variant', 'heading', 'closable', 'no-icon'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;
@@ -77,7 +77,7 @@ export class EAlert extends HTMLElement {
     if (!this._wired || old === val || !this._root) return;
     if (name === 'variant') {
       const variant = this._variant();
-      this._root.setAttribute('data-variant', variant);
+      this._root.dataset.variant = variant;
       // The live-region role follows severity, so it has to move with it:
       // an info banner promoted to error must start interrupting, and an
       // error demoted to info must stop.
@@ -107,7 +107,7 @@ export class EAlert extends HTMLElement {
 
     const root = document.createElement('div');
     root.className = 'ink-alert';
-    root.setAttribute('data-variant', variant);
+    root.dataset.variant = variant;
     root.setAttribute('role', roleFor(variant));
     root.innerHTML = `<span class="ink-alert__icon" aria-hidden="true">${iconSvg(VARIANT_ICON[variant], 20)}</span>
       <div class="ink-alert__content">

--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -23,7 +23,7 @@ import {
  * </e-anchor>
  */
 export class EAnchor extends HTMLElement {
-  static observedAttributes = ['offset-top'];
+  static readonly observedAttributes = ['offset-top'];
 
   private _wired = false;
   private _scrollHandler: (() => void) | null = null;

--- a/src/components/avatar.ts
+++ b/src/components/avatar.ts
@@ -19,7 +19,7 @@ import {
  * <e-avatar name="Ada Lovelace" size="48" shape="circle"></e-avatar>
  */
 export class EAvatar extends HTMLElement {
-  static observedAttributes = ['name', 'src', 'size', 'shape'];
+  static readonly observedAttributes = ['name', 'src', 'size', 'shape'];
 
   private _wrap: HTMLElement | null = null;
   private _failedSrc: string | null = null;
@@ -98,7 +98,7 @@ define('e-avatar', EAvatar);
  * </e-avatar-group>
  */
 export class EAvatarGroup extends HTMLElement {
-  static observedAttributes = ['max', 'size'];
+  static readonly observedAttributes = ['max', 'size'];
 
   private _wired = false;
   private _avatarData: Array<{ name: string; src: string | null }> = [];
@@ -167,7 +167,7 @@ export class EAvatarGroup extends HTMLElement {
 
     // Remove excess avatars from the end.
     while (this._avatarEls.length > max) {
-      group.removeChild(this._avatarEls.pop()!);
+      this._avatarEls.pop()!.remove();
     }
     // Add missing avatars (insert before overflow chip).
     while (this._avatarEls.length < Math.min(max, this._avatarData.length)) {
@@ -187,7 +187,7 @@ export class EAvatarGroup extends HTMLElement {
         patchText(this._overflowEl, `+${overflow}`);
       }
     } else if (this._overflowEl) {
-      group.removeChild(this._overflowEl);
+      this._overflowEl.remove();
       this._overflowEl = null;
     }
   }

--- a/src/components/back-top.ts
+++ b/src/components/back-top.ts
@@ -19,7 +19,7 @@ import { iconSvg } from '../core/icons';
  * <e-back-top visibility-height="200"></e-back-top>
  */
 export class EBackTop extends HTMLElement {
-  static observedAttributes = ['visibility-height', 'label', 'target'];
+  static readonly observedAttributes = ['visibility-height', 'label', 'target'];
 
   private _wired = false;
   private _btn: HTMLButtonElement | null = null;

--- a/src/components/badge-count.ts
+++ b/src/components/badge-count.ts
@@ -13,7 +13,7 @@ import { boolAttr, captureWrap, define, intAttr, patchAttr, patchText } from '..
  * <e-badge-count count="12"><e-button>Inbox</e-button></e-badge-count>
  */
 export class EBadgeCount extends HTMLElement {
-  static observedAttributes = ['count', 'max', 'dot'];
+  static readonly observedAttributes = ['count', 'max', 'dot'];
 
   private _wrap: HTMLElement | null = null;
   private _badge: HTMLElement | null = null;
@@ -47,7 +47,7 @@ export class EBadgeCount extends HTMLElement {
       return;
     }
 
-    if (!this._badge || this._badge.className !== wantClass) {
+    if (this._badge?.className !== wantClass) {
       if (this._badge) this._badge.remove();
       this._badge = document.createElement('span');
       this._badge.className = wantClass;

--- a/src/components/badge.ts
+++ b/src/components/badge.ts
@@ -11,7 +11,7 @@ import { boolAttr, captureWrap, define, patchClassModifier } from '../core/dom';
  * <e-badge inverted>NEW</e-badge>
  */
 export class EBadge extends HTMLElement {
-  static observedAttributes = ['inverted'];
+  static readonly observedAttributes = ['inverted'];
 
   private _wrap: HTMLElement | null = null;
 

--- a/src/components/breadcrumb.ts
+++ b/src/components/breadcrumb.ts
@@ -12,7 +12,7 @@ import { define, patchText } from '../core/dom';
  * </e-breadcrumb>
  */
 export class EBreadcrumb extends HTMLElement {
-  static observedAttributes = ['separator'];
+  static readonly observedAttributes = ['separator'];
 
   private _wired = false;
   private _nav: HTMLElement | null = null;

--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -19,11 +19,11 @@ import { boolAttr, define, patchBoolAttr, patchClassModifier } from '../core/dom
  * <e-button variant="primary">Save</e-button>
  */
 export class EButton extends HTMLElement {
-  static formAssociated = true;
+  static readonly formAssociated = true;
   // `autofocus` is not observed — it only applies at mount time.
-  static observedAttributes = ['variant', 'disabled'];
+  static readonly observedAttributes = ['variant', 'disabled'];
 
-  private internals: ElementInternals;
+  private readonly internals: ElementInternals;
   private _wired = false;
   private _btn: HTMLButtonElement | null = null;
   private _glyph: HTMLElement | null = null;

--- a/src/components/calendar.ts
+++ b/src/components/calendar.ts
@@ -19,13 +19,13 @@ const CELL_COUNT = 42;
  * <e-calendar value="2025-04-26" events='[{"date":"2025-04-30","title":"Release"}]'></e-calendar>
  */
 export class ECalendar extends HTMLElement {
-  static observedAttributes = ['value', 'events'];
+  static readonly observedAttributes = ['value', 'events'];
 
   private _wired = false;
   private _view = { y: 2026, m: 0 };
   private _value = '';
   private _events: CalendarEvent[] = [];
-  private _eventMap = new Map<string, CalendarEvent[]>();
+  private readonly _eventMap = new Map<string, CalendarEvent[]>();
 
   /* DOM references */
   private _titleEyebrow: HTMLElement | null = null;
@@ -223,7 +223,7 @@ export class ECalendar extends HTMLElement {
       const weekRow = document.createElement('div');
       weekRow.className = 'ink-calendar__row';
       weekRow.setAttribute('role', 'row');
-      for (let col = 0; col < DOW_LABELS.length; col++) {
+      for (const _dow of DOW_LABELS) {
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'ink-calendar__cell';
@@ -275,7 +275,7 @@ export class ECalendar extends HTMLElement {
         /* Empty cell — shown as inert div-like */
         patchText(dayNum, '');
         patchBoolAttr(btn, 'disabled', true);
-        btn.removeAttribute('data-day');
+        delete btn.dataset['day'];
         patchAttr(btn, 'aria-selected', null);
         patchAttr(btn, 'aria-hidden', null);
         patchAttr(btn, 'aria-label', 'Outside current month');
@@ -287,7 +287,7 @@ export class ECalendar extends HTMLElement {
         btn.dataset['day'] = String(d);
         patchAttr(btn, 'aria-hidden', null);
 
-        const isSel = sel && sel.getFullYear() === y && sel.getMonth() === m && sel.getDate() === d;
+        const isSel = sel?.getFullYear() === y && sel.getMonth() === m && sel.getDate() === d;
         patchAttr(btn, 'aria-selected', String(!!isSel));
 
         const isToday =
@@ -302,7 +302,7 @@ export class ECalendar extends HTMLElement {
       }
     }
     const selectedCell = this._cells.find((cell) => cell.getAttribute('aria-selected') === 'true');
-    const todayCell = this._cells.find((cell) => cell.getAttribute('data-today') === 'true');
+    const todayCell = this._cells.find((cell) => cell.dataset['today'] === 'true');
     const tabStop = selectedCell ?? todayCell ?? this._cells.find((cell) => !cell.disabled);
     for (const cell of this._cells) cell.tabIndex = cell === tabStop ? 0 : -1;
   }
@@ -342,13 +342,9 @@ export class ECalendar extends HTMLElement {
   ): boolean {
     const children = container.children;
     for (let i = 0; i < shown.length; i++) {
-      if (!children[i] || children[i].textContent !== shown[i].title) return true;
+      if (children[i]?.textContent !== shown[i].title) return true;
     }
-    if (
-      overflow &&
-      (!children[shown.length] || children[shown.length].textContent !== `+${overflow}`)
-    )
-      return true;
+    if (overflow && children[shown.length]?.textContent !== `+${overflow}`) return true;
     return false;
   }
 }

--- a/src/components/card-image.ts
+++ b/src/components/card-image.ts
@@ -1,4 +1,4 @@
-import { define, patchClassModifier, patchText } from '../core/dom';
+import { define, patchClassModifier, patchText, syncEyebrowTitle } from '../core/dom';
 
 /**
  * @summary Card variant with a top cover area and optional footer slot.
@@ -95,36 +95,12 @@ export class ECardImage extends HTMLElement {
       section.insertBefore(this._header, ref);
     }
     const left = this._header.firstElementChild as HTMLElement;
-    this._syncEyebrow(left, eyebrow);
-    this._syncTitle(left, title);
-  }
-
-  private _syncEyebrow(left: HTMLElement, eyebrow: string | null): void {
-    if (eyebrow) {
-      if (!this._eyebrow) {
-        this._eyebrow = document.createElement('div');
-        this._eyebrow.className = 'ink-card__eyebrow';
-        left.insertBefore(this._eyebrow, left.firstChild);
-      }
-      patchText(this._eyebrow, eyebrow);
-    } else if (this._eyebrow) {
-      this._eyebrow.remove();
-      this._eyebrow = null;
-    }
-  }
-
-  private _syncTitle(left: HTMLElement, title: string | null): void {
-    if (title) {
-      if (!this._titleEl) {
-        this._titleEl = document.createElement('h3');
-        this._titleEl.className = 'ink-card__title';
-        left.appendChild(this._titleEl);
-      }
-      patchText(this._titleEl, title);
-    } else if (this._titleEl) {
-      this._titleEl.remove();
-      this._titleEl = null;
-    }
+    const refs = syncEyebrowTitle(left, eyebrow, title, {
+      eyebrow: this._eyebrow,
+      titleEl: this._titleEl,
+    });
+    this._eyebrow = refs.eyebrow;
+    this._titleEl = refs.titleEl;
   }
 
   private _syncFooter(section: HTMLElement): void {

--- a/src/components/card-image.ts
+++ b/src/components/card-image.ts
@@ -1,4 +1,4 @@
-import { define, esc, patchClassModifier, patchText } from '../core/dom';
+import { define, patchClassModifier, patchText } from '../core/dom';
 
 /**
  * @summary Card variant with a top cover area and optional footer slot.
@@ -17,7 +17,7 @@ import { define, esc, patchClassModifier, patchText } from '../core/dom';
  * </e-card-image>
  */
 export class ECardImage extends HTMLElement {
-  static observedAttributes = ['title', 'eyebrow', 'cover'];
+  static readonly observedAttributes = ['title', 'eyebrow', 'cover'];
 
   private _section: HTMLElement | null = null;
   private _cover: HTMLElement | null = null;
@@ -51,77 +51,92 @@ export class ECardImage extends HTMLElement {
 
   private _render(): void {
     const section = this._section!;
-    const cover = this.getAttribute('cover');
-    const title = this.getAttribute('title');
-    const eyebrow = this.getAttribute('eyebrow');
+    this._syncCover(section, this.getAttribute('cover'));
+    this._syncHeader(section, this.getAttribute('title'), this.getAttribute('eyebrow'));
+    if (this._body && this._body.parentElement !== section) section.appendChild(this._body);
+    this._syncFooter(section);
+  }
 
-    if (cover != null) {
-      if (!this._cover) {
-        this._cover = document.createElement('div');
-        this._cover.classList.add('ink-card__cover');
-        section.insertBefore(this._cover, section.firstChild);
+  private _syncCover(section: HTMLElement, cover: string | null): void {
+    if (cover == null) {
+      if (this._cover) {
+        this._cover.remove();
+        this._cover = null;
       }
-      const isHatch = cover === 'hatch' || cover.startsWith('hatch');
-      patchClassModifier(this._cover, 'ink-card__cover--', isHatch ? 'hatch' : null);
-      patchText(this._cover, isHatch ? '' : cover);
-    } else if (this._cover) {
-      this._cover.remove();
-      this._cover = null;
+      return;
     }
+    if (!this._cover) {
+      this._cover = document.createElement('div');
+      this._cover.classList.add('ink-card__cover');
+      section.insertBefore(this._cover, section.firstChild);
+    }
+    const isHatch = cover === 'hatch' || cover.startsWith('hatch');
+    patchClassModifier(this._cover, 'ink-card__cover--', isHatch ? 'hatch' : null);
+    patchText(this._cover, isHatch ? '' : cover);
+  }
 
+  private _syncHeader(section: HTMLElement, title: string | null, eyebrow: string | null): void {
     const needHeader = !!(title || eyebrow);
-    if (needHeader) {
-      if (!this._header) {
-        this._header = document.createElement('header');
-        this._header.className = 'ink-card__header';
-        const left = document.createElement('div');
-        this._header.appendChild(left);
-        const ref = this._cover ? this._cover.nextSibling : section.firstChild;
-        section.insertBefore(this._header, ref);
-      }
-      const left = this._header.firstElementChild as HTMLElement;
-      if (eyebrow) {
-        if (!this._eyebrow) {
-          this._eyebrow = document.createElement('div');
-          this._eyebrow.className = 'ink-card__eyebrow';
-          left.insertBefore(this._eyebrow, left.firstChild);
-        }
-        patchText(this._eyebrow, eyebrow);
-      } else if (this._eyebrow) {
-        this._eyebrow.remove();
+    if (!needHeader) {
+      if (this._header) {
+        this._header.remove();
+        this._header = null;
         this._eyebrow = null;
-      }
-      if (title) {
-        if (!this._titleEl) {
-          this._titleEl = document.createElement('h3');
-          this._titleEl.className = 'ink-card__title';
-          left.appendChild(this._titleEl);
-        }
-        patchText(this._titleEl, title);
-      } else if (this._titleEl) {
-        this._titleEl.remove();
         this._titleEl = null;
       }
-    } else if (this._header) {
-      this._header.remove();
-      this._header = null;
+      return;
+    }
+    if (!this._header) {
+      this._header = document.createElement('header');
+      this._header.className = 'ink-card__header';
+      const left = document.createElement('div');
+      this._header.appendChild(left);
+      const ref = this._cover ? this._cover.nextSibling : section.firstChild;
+      section.insertBefore(this._header, ref);
+    }
+    const left = this._header.firstElementChild as HTMLElement;
+    this._syncEyebrow(left, eyebrow);
+    this._syncTitle(left, title);
+  }
+
+  private _syncEyebrow(left: HTMLElement, eyebrow: string | null): void {
+    if (eyebrow) {
+      if (!this._eyebrow) {
+        this._eyebrow = document.createElement('div');
+        this._eyebrow.className = 'ink-card__eyebrow';
+        left.insertBefore(this._eyebrow, left.firstChild);
+      }
+      patchText(this._eyebrow, eyebrow);
+    } else if (this._eyebrow) {
+      this._eyebrow.remove();
       this._eyebrow = null;
+    }
+  }
+
+  private _syncTitle(left: HTMLElement, title: string | null): void {
+    if (title) {
+      if (!this._titleEl) {
+        this._titleEl = document.createElement('h3');
+        this._titleEl.className = 'ink-card__title';
+        left.appendChild(this._titleEl);
+      }
+      patchText(this._titleEl, title);
+    } else if (this._titleEl) {
+      this._titleEl.remove();
       this._titleEl = null;
     }
+  }
 
-    if (this._body && this._body.parentElement !== section) section.appendChild(this._body);
-
-    if (this._footerSlot) {
-      if (!this._footer) {
-        this._footer = document.createElement('footer');
-        this._footer.className = 'ink-card__footer';
-        this._footer.appendChild(this._footerSlot);
-        section.appendChild(this._footer);
-      } else if (this._footer.parentElement !== section) {
-        section.appendChild(this._footer);
-      }
+  private _syncFooter(section: HTMLElement): void {
+    if (!this._footerSlot) return;
+    if (!this._footer) {
+      this._footer = document.createElement('footer');
+      this._footer.className = 'ink-card__footer';
+      this._footer.appendChild(this._footerSlot);
+      section.appendChild(this._footer);
+    } else if (this._footer.parentElement !== section) {
+      section.appendChild(this._footer);
     }
-    void esc;
   }
 }
 

--- a/src/components/card.ts
+++ b/src/components/card.ts
@@ -1,4 +1,4 @@
-import { define, patchText } from '../core/dom';
+import { define, syncEyebrowTitle } from '../core/dom';
 
 /**
  * @summary Container with optional eyebrow, title and action area.
@@ -71,38 +71,14 @@ export class ECard extends HTMLElement {
       section.insertBefore(this._header, section.firstChild);
     }
     const left = this._header.firstElementChild as HTMLElement;
-    this._syncEyebrow(left, eyebrow);
-    this._syncTitle(left, title);
+    const refs = syncEyebrowTitle(left, eyebrow, title, {
+      eyebrow: this._eyebrow,
+      titleEl: this._titleEl,
+    });
+    this._eyebrow = refs.eyebrow;
+    this._titleEl = refs.titleEl;
     if (this._action && this._action.parentElement !== this._header) {
       this._header.appendChild(this._action);
-    }
-  }
-
-  private _syncEyebrow(left: HTMLElement, eyebrow: string | null): void {
-    if (eyebrow) {
-      if (!this._eyebrow) {
-        this._eyebrow = document.createElement('div');
-        this._eyebrow.className = 'ink-card__eyebrow';
-        left.insertBefore(this._eyebrow, left.firstChild);
-      }
-      patchText(this._eyebrow, eyebrow);
-    } else if (this._eyebrow) {
-      this._eyebrow.remove();
-      this._eyebrow = null;
-    }
-  }
-
-  private _syncTitle(left: HTMLElement, title: string | null): void {
-    if (title) {
-      if (!this._titleEl) {
-        this._titleEl = document.createElement('h3');
-        this._titleEl.className = 'ink-card__title';
-        left.appendChild(this._titleEl);
-      }
-      patchText(this._titleEl, title);
-    } else if (this._titleEl) {
-      this._titleEl.remove();
-      this._titleEl = null;
     }
   }
 }

--- a/src/components/card.ts
+++ b/src/components/card.ts
@@ -16,7 +16,7 @@ import { define, patchText } from '../core/dom';
  * </e-card>
  */
 export class ECard extends HTMLElement {
-  static observedAttributes = ['title', 'eyebrow'];
+  static readonly observedAttributes = ['title', 'eyebrow'];
 
   private _section: HTMLElement | null = null;
   private _header: HTMLElement | null = null;
@@ -48,51 +48,62 @@ export class ECard extends HTMLElement {
 
   private _render(): void {
     const section = this._section!;
-    const title = this.getAttribute('title');
-    const eyebrow = this.getAttribute('eyebrow');
-    const needHeader = !!(title || eyebrow || this._action);
+    this._syncHeader(section, this.getAttribute('title'), this.getAttribute('eyebrow'));
+    if (this._body && this._body.parentElement !== section) section.appendChild(this._body);
+  }
 
-    if (needHeader) {
-      if (!this._header) {
-        this._header = document.createElement('header');
-        this._header.className = 'ink-card__header';
-        const left = document.createElement('div');
-        this._header.appendChild(left);
-        section.insertBefore(this._header, section.firstChild);
-      }
-      const left = this._header.firstElementChild as HTMLElement;
-      if (eyebrow) {
-        if (!this._eyebrow) {
-          this._eyebrow = document.createElement('div');
-          this._eyebrow.className = 'ink-card__eyebrow';
-          left.insertBefore(this._eyebrow, left.firstChild);
-        }
-        patchText(this._eyebrow, eyebrow);
-      } else if (this._eyebrow) {
-        this._eyebrow.remove();
+  private _syncHeader(section: HTMLElement, title: string | null, eyebrow: string | null): void {
+    const needHeader = !!(title || eyebrow || this._action);
+    if (!needHeader) {
+      if (this._header) {
+        this._header.remove();
+        this._header = null;
         this._eyebrow = null;
-      }
-      if (title) {
-        if (!this._titleEl) {
-          this._titleEl = document.createElement('h3');
-          this._titleEl.className = 'ink-card__title';
-          left.appendChild(this._titleEl);
-        }
-        patchText(this._titleEl, title);
-      } else if (this._titleEl) {
-        this._titleEl.remove();
         this._titleEl = null;
       }
-      if (this._action && this._action.parentElement !== this._header) {
-        this._header.appendChild(this._action);
+      return;
+    }
+    if (!this._header) {
+      this._header = document.createElement('header');
+      this._header.className = 'ink-card__header';
+      const left = document.createElement('div');
+      this._header.appendChild(left);
+      section.insertBefore(this._header, section.firstChild);
+    }
+    const left = this._header.firstElementChild as HTMLElement;
+    this._syncEyebrow(left, eyebrow);
+    this._syncTitle(left, title);
+    if (this._action && this._action.parentElement !== this._header) {
+      this._header.appendChild(this._action);
+    }
+  }
+
+  private _syncEyebrow(left: HTMLElement, eyebrow: string | null): void {
+    if (eyebrow) {
+      if (!this._eyebrow) {
+        this._eyebrow = document.createElement('div');
+        this._eyebrow.className = 'ink-card__eyebrow';
+        left.insertBefore(this._eyebrow, left.firstChild);
       }
-    } else if (this._header) {
-      this._header.remove();
-      this._header = null;
+      patchText(this._eyebrow, eyebrow);
+    } else if (this._eyebrow) {
+      this._eyebrow.remove();
       this._eyebrow = null;
+    }
+  }
+
+  private _syncTitle(left: HTMLElement, title: string | null): void {
+    if (title) {
+      if (!this._titleEl) {
+        this._titleEl = document.createElement('h3');
+        this._titleEl.className = 'ink-card__title';
+        left.appendChild(this._titleEl);
+      }
+      patchText(this._titleEl, title);
+    } else if (this._titleEl) {
+      this._titleEl.remove();
       this._titleEl = null;
     }
-    if (this._body && this._body.parentElement !== section) section.appendChild(this._body);
   }
 }
 

--- a/src/components/cascader.ts
+++ b/src/components/cascader.ts
@@ -22,7 +22,7 @@ import { isTreeData } from '../core/data';
  * <e-cascader data='[{"value":"eu","label":"Europe","children":[{"value":"de","label":"Germany"}]}]' value="eu,de"></e-cascader>
  */
 export class ECascader extends BaseFormControl {
-  static observedAttributes = ['value', 'data', 'options', 'placeholder'];
+  static readonly observedAttributes = ['value', 'data', 'options', 'placeholder'];
 
   private _options: CascaderOption[] = [];
   private _path: string[] = [];
@@ -118,7 +118,7 @@ export class ECascader extends BaseFormControl {
     this._trigger = document.createElement('button');
     this._trigger.type = 'button';
     this._trigger.className = 'ink-select__trigger';
-    this._trigger.setAttribute('data-trigger', '');
+    this._trigger.dataset['trigger'] = '';
     this._trigger.setAttribute('aria-haspopup', 'listbox');
     this._trigger.setAttribute('aria-expanded', 'false');
 
@@ -218,7 +218,7 @@ export class ECascader extends BaseFormControl {
       items[0]?.focus();
     } else if (e.key === 'End') {
       e.preventDefault();
-      items[items.length - 1]?.focus();
+      items.at(-1)?.focus();
     } else if (e.key === 'ArrowRight') {
       e.preventDefault();
       const v = item.dataset['value'] ?? '';
@@ -301,7 +301,7 @@ export class ECascader extends BaseFormControl {
     const cols = this._resolveCols();
 
     while (this._menu.children.length > cols.length) {
-      this._menu.removeChild(this._menu.lastChild!);
+      this._menu.lastChild!.remove();
     }
 
     const newKeys: string[] = [];

--- a/src/components/checkbox-group.ts
+++ b/src/components/checkbox-group.ts
@@ -20,7 +20,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-checkbox-group>
  */
 export class ECheckboxGroup extends BaseFormControl {
-  static observedAttributes = ['value', 'layout'];
+  static readonly observedAttributes = ['value', 'layout'];
 
   private _wired = false;
   private _opts: Array<{ value: string; label: string }> = [];

--- a/src/components/checkbox.ts
+++ b/src/components/checkbox.ts
@@ -19,7 +19,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-checkbox checked label="Accept terms"></e-checkbox>
  */
 export class ECheckbox extends BaseFormControl {
-  static observedAttributes = ['checked', 'label', 'disabled', 'value'];
+  static readonly observedAttributes = ['checked', 'label', 'disabled', 'value'];
 
   private _wired = false;
   private _cb: HTMLInputElement | null = null;
@@ -53,11 +53,21 @@ export class ECheckbox extends BaseFormControl {
     this._syncFormValue();
     this._cb!.addEventListener('change', (e) => {
       const v = (e.target as HTMLInputElement).checked;
-      if (v) this.setAttribute('checked', '');
-      else this.removeAttribute('checked');
+      if (v) this._markChecked();
+      else this._markUnchecked();
       this._syncFormValue();
       this.dispatchEvent(new CustomEvent('e-change', { detail: { checked: v }, bubbles: true }));
     });
+  }
+
+  /** Reflects the checked state to the `checked` attribute. */
+  private _markChecked(): void {
+    this.setAttribute('checked', '');
+  }
+
+  /** Clears the `checked` attribute. */
+  private _markUnchecked(): void {
+    this.removeAttribute('checked');
   }
 
   attributeChangedCallback(name: string) {
@@ -89,8 +99,8 @@ export class ECheckbox extends BaseFormControl {
     return this._cb?.checked || false;
   }
   set checked(v: boolean) {
-    if (v) this.setAttribute('checked', '');
-    else this.removeAttribute('checked');
+    if (v) this._markChecked();
+    else this._markUnchecked();
   }
 
   /** Submitted value when checked (defaults to "on"). */

--- a/src/components/chip.ts
+++ b/src/components/chip.ts
@@ -18,7 +18,7 @@ import { addCleanup, boolAttr, captureWrap, define, patchBoolAttr, runCleanups }
  * <e-chip selected>Today</e-chip>
  */
 export class EChip extends HTMLElement {
-  static observedAttributes = ['selected', 'disabled'];
+  static readonly observedAttributes = ['selected', 'disabled'];
 
   private _wrap: HTMLButtonElement | null = null;
 

--- a/src/components/collapse.ts
+++ b/src/components/collapse.ts
@@ -33,18 +33,18 @@ interface PanelDef {
  * </e-collapse>
  */
 export class ECollapse extends HTMLElement {
-  static observedAttributes = ['accordion'];
+  static readonly observedAttributes = ['accordion'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;
-  private _panels = new Map<string, HTMLDetailsElement>();
+  private readonly _panels = new Map<string, HTMLDetailsElement>();
   /**
    * Panels whose next `toggle` we caused ourselves. `toggle` is dispatched
    * asynchronously, so a synchronous "am I syncing" flag would already be back
    * to false by the time the event lands — the closes an accordion performs
    * would then be reported as if the user had made them.
    */
-  private _suppressed = new Set<HTMLDetailsElement>();
+  private readonly _suppressed = new Set<HTMLDetailsElement>();
 
   connectedCallback() {
     if (!this._wired) {

--- a/src/components/date-picker.ts
+++ b/src/components/date-picker.ts
@@ -9,7 +9,7 @@ import {
   runCleanups,
 } from '../core/dom';
 import { iconSvg } from '../core/icons';
-import { pad2, parseYMD, ymd } from '../core/date';
+import { parseYMD, ymd } from '../core/date';
 import { BaseFormControl } from '../core/base-form-control';
 
 const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -30,7 +30,7 @@ const CELL_COUNT = 42;
  * <e-date-picker value="2025-04-26"></e-date-picker>
  */
 export class EDatePicker extends BaseFormControl {
-  static observedAttributes = ['value', 'placeholder'];
+  static readonly observedAttributes = ['value', 'placeholder'];
 
   private _wired = false;
   private _view = { y: 2026, m: 0 };
@@ -132,85 +132,105 @@ export class EDatePicker extends BaseFormControl {
     const ke = e as KeyboardEvent;
     const target = ke.target as Element;
 
-    /* Trigger: ArrowDown / Enter / Space opens popover */
-    if (target.closest('[data-trigger]') && this._pop) {
-      if (ke.key === 'ArrowDown' || ke.key === 'Enter' || ke.key === ' ') {
-        ke.preventDefault();
-        this._setOpen(true);
-        this._focusInitialCell();
-      }
-      return;
-    }
+    if (this._handleTriggerKeydown(ke, target)) return;
 
     /* Inside grid */
     const cell = target.closest<HTMLButtonElement>('.ink-datepicker__cell');
     if (!cell || !this._pop || this._pop.hidden) return;
 
     const focusables = this._cells.filter((b) => !b.disabled);
-    const idx = focusables.indexOf(cell);
-    if (idx < 0) return;
+    if (focusables.indexOf(cell) < 0) return;
 
-    const moveBy = (delta: number): void => {
-      const dayNum = Number(cell.dataset['day']);
-      const target = new Date(this._view.y, this._view.m, dayNum + delta);
-      this._view = { y: target.getFullYear(), m: target.getMonth() };
-      this._patchGrid();
-      const newCell = this._cells.find(
-        (b) => Number(b.dataset['day']) === target.getDate() && !b.disabled,
-      );
-      newCell?.focus();
-    };
-
-    if (ke.key === 'ArrowLeft') {
-      ke.preventDefault();
-      moveBy(-1);
-    } else if (ke.key === 'ArrowRight') {
-      ke.preventDefault();
-      moveBy(1);
-    } else if (ke.key === 'ArrowUp') {
-      ke.preventDefault();
-      moveBy(-7);
-    } else if (ke.key === 'ArrowDown') {
-      ke.preventDefault();
-      moveBy(7);
-    } else if (ke.key === 'PageUp') {
-      ke.preventDefault();
-      let m = this._view.m - 1;
-      let y = this._view.y;
-      if (m < 0) {
-        m = 11;
-        y -= 1;
-      }
-      this._view = { y, m };
-      this._patchGrid();
-      this._focusInitialCell();
-    } else if (ke.key === 'PageDown') {
-      ke.preventDefault();
-      let m = this._view.m + 1;
-      let y = this._view.y;
-      if (m > 11) {
-        m = 0;
-        y += 1;
-      }
-      this._view = { y, m };
-      this._patchGrid();
-      this._focusInitialCell();
-    } else if (ke.key === 'Home') {
-      ke.preventDefault();
-      moveBy(-(this._cells.indexOf(cell) % 7));
-    } else if (ke.key === 'End') {
-      ke.preventDefault();
-      moveBy(6 - (this._cells.indexOf(cell) % 7));
-    } else if (ke.key === 'Enter' || ke.key === ' ') {
-      ke.preventDefault();
-      cell.click();
-    }
+    this._handleGridKeydown(ke, cell);
   };
+
+  /** Trigger: ArrowDown / Enter / Space opens popover. Returns whether the key targeted the trigger. */
+  private _handleTriggerKeydown(ke: KeyboardEvent, target: Element): boolean {
+    if (!target.closest('[data-trigger]') || !this._pop) return false;
+    if (ke.key === 'ArrowDown' || ke.key === 'Enter' || ke.key === ' ') {
+      ke.preventDefault();
+      this._setOpen(true);
+      this._focusInitialCell();
+    }
+    return true;
+  }
+
+  /** Keyboard navigation once focus is inside the grid. */
+  private _handleGridKeydown(ke: KeyboardEvent, cell: HTMLButtonElement): void {
+    switch (ke.key) {
+      case 'ArrowLeft':
+        ke.preventDefault();
+        this._moveFocusBy(cell, -1);
+        break;
+      case 'ArrowRight':
+        ke.preventDefault();
+        this._moveFocusBy(cell, 1);
+        break;
+      case 'ArrowUp':
+        ke.preventDefault();
+        this._moveFocusBy(cell, -7);
+        break;
+      case 'ArrowDown':
+        ke.preventDefault();
+        this._moveFocusBy(cell, 7);
+        break;
+      case 'PageUp':
+        ke.preventDefault();
+        this._pageMonth(-1);
+        break;
+      case 'PageDown':
+        ke.preventDefault();
+        this._pageMonth(1);
+        break;
+      case 'Home':
+        ke.preventDefault();
+        this._moveFocusBy(cell, -(this._cells.indexOf(cell) % 7));
+        break;
+      case 'End':
+        ke.preventDefault();
+        this._moveFocusBy(cell, 6 - (this._cells.indexOf(cell) % 7));
+        break;
+      case 'Enter':
+      case ' ':
+        ke.preventDefault();
+        cell.click();
+        break;
+    }
+  }
+
+  /** Move grid focus `delta` days from `cell`, paging the month view if needed. */
+  private _moveFocusBy(cell: HTMLButtonElement, delta: number): void {
+    const dayNum = Number(cell.dataset['day']);
+    const target = new Date(this._view.y, this._view.m, dayNum + delta);
+    this._view = { y: target.getFullYear(), m: target.getMonth() };
+    this._patchGrid();
+    const newCell = this._cells.find(
+      (b) => Number(b.dataset['day']) === target.getDate() && !b.disabled,
+    );
+    newCell?.focus();
+  }
+
+  /** Step the view by `delta` months (PageUp/PageDown) and refocus. */
+  private _pageMonth(delta: number): void {
+    let m = this._view.m + delta;
+    let y = this._view.y;
+    if (m < 0) {
+      m = 11;
+      y -= 1;
+    }
+    if (m > 11) {
+      m = 0;
+      y += 1;
+    }
+    this._view = { y, m };
+    this._patchGrid();
+    this._focusInitialCell();
+  }
 
   private _focusInitialCell(): void {
     const sel = parseYMD(this._value);
     let target: HTMLButtonElement | undefined;
-    if (sel && sel.getFullYear() === this._view.y && sel.getMonth() === this._view.m) {
+    if (sel?.getFullYear() === this._view.y && sel.getMonth() === this._view.m) {
       target = this._cells.find((b) => Number(b.dataset['day']) === sel.getDate() && !b.disabled);
     }
     if (!target) {
@@ -221,7 +241,7 @@ export class EDatePicker extends BaseFormControl {
         );
       }
     }
-    if (!target) target = this._cells.find((b) => !b.disabled);
+    target ??= this._cells.find((b) => !b.disabled);
     for (const cell of this._cells) cell.tabIndex = cell === target ? 0 : -1;
     target?.focus();
   }
@@ -323,7 +343,7 @@ export class EDatePicker extends BaseFormControl {
       const weekRow = document.createElement('div');
       weekRow.className = 'ink-datepicker__row';
       weekRow.setAttribute('role', 'row');
-      for (let col = 0; col < DOW_LABELS.length; col++) {
+      for (const _dow of DOW_LABELS) {
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'ink-datepicker__cell';
@@ -349,12 +369,10 @@ export class EDatePicker extends BaseFormControl {
       } else {
         this._triggerSpan.textContent = this._value;
       }
-    } else {
+    } else if (this._triggerSpan.firstChild !== this._placeholderSpan) {
       // Show the cached placeholder span — no innerHTML reassignment.
-      if (this._triggerSpan.firstChild !== this._placeholderSpan) {
-        this._triggerSpan.textContent = '';
-        this._triggerSpan.appendChild(this._placeholderSpan);
-      }
+      this._triggerSpan.textContent = '';
+      this._triggerSpan.appendChild(this._placeholderSpan);
     }
   }
 
@@ -379,7 +397,7 @@ export class EDatePicker extends BaseFormControl {
         /* Empty cell */
         patchText(btn, '');
         patchBoolAttr(btn, 'disabled', true);
-        btn.removeAttribute('data-day');
+        delete btn.dataset['day'];
         patchAttr(btn, 'aria-selected', null);
         patchAttr(btn, 'aria-label', null);
         patchAttr(btn, 'data-today', null);
@@ -387,8 +405,7 @@ export class EDatePicker extends BaseFormControl {
         patchText(btn, String(dayNum));
         patchBoolAttr(btn, 'disabled', false);
         btn.dataset['day'] = String(dayNum);
-        const isSel =
-          sel && sel.getFullYear() === y && sel.getMonth() === m && sel.getDate() === dayNum;
+        const isSel = sel?.getFullYear() === y && sel.getMonth() === m && sel.getDate() === dayNum;
         patchAttr(btn, 'aria-selected', String(!!isSel));
         const isToday =
           today.getFullYear() === y && today.getMonth() === m && today.getDate() === dayNum;
@@ -399,7 +416,7 @@ export class EDatePicker extends BaseFormControl {
     }
 
     const selectedCell = this._cells.find((cell) => cell.getAttribute('aria-selected') === 'true');
-    const todayCell = this._cells.find((cell) => cell.getAttribute('data-today') === 'true');
+    const todayCell = this._cells.find((cell) => cell.dataset['today'] === 'true');
     const tabStop = selectedCell ?? todayCell ?? this._cells.find((cell) => !cell.disabled);
     for (const cell of this._cells) cell.tabIndex = cell === tabStop ? 0 : -1;
   }
@@ -447,4 +464,4 @@ export class EDatePicker extends BaseFormControl {
 
 define('e-date-picker', EDatePicker);
 
-export { pad2 };
+export { pad2 } from '../core/date';

--- a/src/components/description-list.ts
+++ b/src/components/description-list.ts
@@ -21,7 +21,7 @@ import { define, intAttr } from '../core/dom';
  * </e-description-list>
  */
 export class EDescriptionList extends HTMLElement {
-  static observedAttributes = ['columns', 'layout', 'bordered'];
+  static readonly observedAttributes = ['columns', 'layout', 'bordered'];
 
   private _wired = false;
   private _dl: HTMLElement | null = null;

--- a/src/components/dialog.ts
+++ b/src/components/dialog.ts
@@ -70,7 +70,7 @@ export type DialogCloseReason = 'close-button' | 'escape' | 'backdrop' | 'api';
  * </e-dialog>
  */
 export class EDialog extends HTMLElement {
-  static observedAttributes = ['open', 'heading', 'size', 'no-close', 'aria-label'];
+  static readonly observedAttributes = ['open', 'heading', 'size', 'no-close', 'aria-label'];
 
   private _wired = false;
   private _dialog: HTMLDialogElement | null = null;

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -168,3 +168,47 @@ export function captureWrap(host: HTMLElement, tag = 'span'): HTMLElement {
   host.appendChild(wrap);
   return wrap;
 }
+
+/** Current eyebrow/title child elements tracked by {@link syncEyebrowTitle}'s caller. */
+export interface EyebrowTitleRefs {
+  eyebrow: HTMLElement | null;
+  titleEl: HTMLElement | null;
+}
+
+/**
+ * Shared by `e-card` and `e-card-image`: syncs the optional eyebrow label and
+ * title heading inside a card header's left column, creating/removing each
+ * element only as needed. Returns the (possibly updated) refs for the caller
+ * to store back on its instance.
+ */
+export function syncEyebrowTitle(
+  left: HTMLElement,
+  eyebrow: string | null,
+  title: string | null,
+  refs: EyebrowTitleRefs,
+): EyebrowTitleRefs {
+  let { eyebrow: eyebrowEl, titleEl } = refs;
+  if (eyebrow) {
+    if (!eyebrowEl) {
+      eyebrowEl = document.createElement('div');
+      eyebrowEl.className = 'ink-card__eyebrow';
+      left.insertBefore(eyebrowEl, left.firstChild);
+    }
+    patchText(eyebrowEl, eyebrow);
+  } else if (eyebrowEl) {
+    eyebrowEl.remove();
+    eyebrowEl = null;
+  }
+  if (title) {
+    if (!titleEl) {
+      titleEl = document.createElement('h3');
+      titleEl.className = 'ink-card__title';
+      left.appendChild(titleEl);
+    }
+    patchText(titleEl, title);
+  } else if (titleEl) {
+    titleEl.remove();
+    titleEl = null;
+  }
+  return { eyebrow: eyebrowEl, titleEl };
+}


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched) — #32's 40 files, plus `reactivity.test.ts` and `CHANGELOG.md`
- [x] Demo/story/docs updated if needed — `CHANGELOG.md` records the script/workflow hardening and the shared card helper; no API or behaviour change to document
- [x] CSS output builds locally (`npm run build`)

Carries #32 (`claude/workflow-security-fixes-2p2k9b`) forward. That PR went un-mergeable (`dirty`) after #34/#35/#36/#37 landed on `main`, and its SonarCloud quality gate failed on **72.7% coverage of new code** (requires ≥ 80%). Both are fixed here.

**Merged latest `main` (6bbdfb5) into the work.** Four conflicts, all the same shape: `main` added the `required` / `required-message` attributes to `observedAttributes` while #32 marked the same field `readonly`. Resolved by keeping both, in `cascader.ts`, `checkbox-group.ts`, `checkbox.ts` and `date-picker.ts`.

**Closed the coverage gate.** Every uncovered new line sat on a *shrinking* path of the refactors — code that only runs when an attribute goes away, which nothing exercised:

| Uncovered before | Now covered by |
| --- | --- |
| `core/dom.ts` `syncEyebrowTitle()` element-removal branches | `e-card` losing `title`, then `eyebrow`, with and without an `action` slot |
| `card.ts` / `card-image.ts` header teardown, cover removal, footer re-attach | `e-card-image` losing `cover`/`eyebrow`/`title`; a detached footer re-attached on the next render |
| `date-picker.ts` extracted `Home`/`End` handlers and `_pageMonth` year wrap | grid keyboard tests incl. `PageUp` from January and `PageDown` from December |
| `avatar.ts` `_patchMax` pop/overflow-chip removal | `e-avatar-group` `max` 4 → 5 → 2 |
| `calendar.ts` `_needsEventUpdate` | same-count/changed-title and changed-overflow event repaints |
| `cascader.ts` `items.at(-1)` | `End` key in a cascader column |

Changed-line coverage measured off `reports/coverage/lcov.info` against the diff: **187/187 lines (100%)** and **108/112 conditions (96%)**, ≈ 98.7% on Sonar's line+condition metric — comfortably over the 80% gate. All new tests went into the existing `reactivity.test.ts` rather than a new suite file, per `CONTRIBUTING.md`.

Review threads on #32 were all answered there and their fixes are included in this history (`791e7c5`, `c569563`, `9e48678`).

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm run build` (95 tags written to `dist/elements.d.ts`)
- [x] `npm run size` (barrel 39.67 kB / 40 kB)
- [x] `node sample-app/validate.mjs` — 20/20
- [x] `vitest run --coverage` — 643 passed, 8 failed, all 8 in `screenshots.test.ts`

## Notes

The 8 screenshot failures are pre-existing in this sandbox and unrelated to the diff — they are image-dimension mismatches (e.g. `296×102px` expected vs `296×100px` received) from this container's Chromium/font stack differing from the pinned CI image that produced the baselines. I confirmed this by running `screenshots.test.ts` in a clean worktree of unmodified `main` (6bbdfb5): **identical 8 failures**. They should pass on CI runners.

The `github-advanced-security` check on #32 also failed for an infrastructure reason, not a code one — its log shows `Failed to fetch diff between <base> and <head>`, i.e. the action could not compare against the stale base. It should resolve against this fresh base.

`#32` can be closed in favour of this PR, or — if you would rather keep #32's thread and number — say so and I will push this merge onto `claude/workflow-security-fixes-2p2k9b` instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb1aRWN6pZUayRGiqy2Gwu)_