### PR TITLE
fix: clear the open SonarQube findings on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,21 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Cleared the open SonarQube Cloud findings on `main`. `observedAttributes`,
+  `formAssociated` and the bound event-handler fields are now declared
+  `readonly`, `<e-form-item>`'s renderer and `<e-empty>`'s attribute callback
+  are split into one sync method per slot to come back under the
+  cognitive-complexity budget, and the `data-*` writes that had a `dataset`
+  equivalent use it. None of this changes rendered output or the public
+  attribute, event and slot contract.
+- `scripts/inline-site-css.mjs` normalises `VITE_SITE_BASE` by splitting on
+  `/` instead of trimming with `/\/+$/`, which backtracked super-linearly on a
+  run of slashes. A base with interior double slashes now collapses to a single
+  separator rather than producing a broken `/a//b/` prefix.
+- `eslint.config.mjs` builds its config with `defineConfig`/`globalIgnores`
+  from `eslint/config`; typescript-eslint deprecated the `tseslint.config()`
+  wrapper it used before.
+
 - All thirteen `BaseFormControl` subclasses now participate in native
   constraint validation. Composite controls implement a shared `required`
   contract through `ElementInternals`; text and number controls mirror their

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,22 +1,24 @@
 // EPaper · ESLint flat config.
 // Lints the runtime sources only; storybook/demo are excluded.
+import { defineConfig, globalIgnores } from 'eslint/config';
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  {
-    ignores: [
-      'dist/**',
-      'reports/**',
-      'storybook-static/**',
-      'src/demo/**',
-      'src/stories/**',
-      'scripts/**',
-      'node_modules/**',
-    ],
-  },
+// `defineConfig`/`globalIgnores` from eslint/config rather than
+// `tseslint.config()`: typescript-eslint deprecated its own wrapper in favour
+// of the one ESLint now ships, and the two are otherwise interchangeable.
+export default defineConfig([
+  globalIgnores([
+    'dist/**',
+    'reports/**',
+    'storybook-static/**',
+    'src/demo/**',
+    'src/stories/**',
+    'scripts/**',
+    'node_modules/**',
+  ]),
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  tseslint.configs.recommended,
   {
     files: ['src/**/*.ts'],
     languageOptions: {
@@ -36,4 +38,4 @@ export default tseslint.config(
       eqeqeq: ['error', 'smart'],
     },
   },
-);
+]);

--- a/scripts/gen-pages-index.mjs
+++ b/scripts/gen-pages-index.mjs
@@ -8,7 +8,12 @@ import { resolve, sep } from 'node:path';
 const outArg = process.argv[2] ?? '_site/index.html';
 const outRoot = resolve(process.cwd());
 const out = resolve(outRoot, outArg);
-if (out !== outRoot && !out.startsWith(outRoot + sep)) {
+// Containment check on the canonicalised path: the argument is maintainer-supplied
+// in CI, but resolving it first and then requiring the repository root as a literal
+// prefix keeps a stray `../` from writing outside the checkout. Comparing against
+// `outRoot + sep` also rules out a sibling directory that merely shares the prefix
+// (`/repo-backup` vs `/repo`), and the root itself, which is a directory.
+if (!out.startsWith(outRoot + sep)) {
   console.error(`[gen-pages-index] refusing to write outside ${outRoot}: ${out}`);
   process.exit(1);
 }

--- a/scripts/gen-readmes.mjs
+++ b/scripts/gen-readmes.mjs
@@ -40,10 +40,12 @@ const screenshotFiles = existsSync(screenshotsDir)
  * Component file `input-number.ts` → key `inputnumber`
  * Screenshot   `inputs-inputnumber--default.png` → middle `inputnumber`
  */
+const SCREENSHOT_MIDDLE_RE = /^[a-z0-9]+-([a-z0-9]+)--/;
+
 function findScreenshot(basenameNoExt) {
-  const key = basenameNoExt.replaceAll(/-/g, '');
+  const key = basenameNoExt.replaceAll('-', '');
   for (const f of screenshotFiles) {
-    const m = f.match(/^[a-z0-9]+-([a-z0-9]+)--/);
+    const m = SCREENSHOT_MIDDLE_RE.exec(f);
     if (m && m[1] === key) return f;
   }
   return null;
@@ -51,7 +53,7 @@ function findScreenshot(basenameNoExt) {
 
 function escMd(s) {
   return String(s)
-    .replaceAll(/\|/g, String.raw`\|`)
+    .replaceAll('|', String.raw`\|`)
     .replaceAll(/\r?\n/g, ' ');
 }
 

--- a/scripts/inline-site-css.mjs
+++ b/scripts/inline-site-css.mjs
@@ -11,7 +11,10 @@ const assetsDir = join(distDir, 'assets');
 
 // Mirrors `base` in vite.site.config.ts. Normalised to a single leading and
 // trailing slash so the rewritten chunk URLs resolve from any page depth.
-const trimmedSiteBase = (process.env.VITE_SITE_BASE || '/').replace(/^\/+/, '').replace(/\/+$/, '');
+// Split/filter/join rather than a trailing-slash regex: `/\/+$/` backtracks
+// super-linearly on a run of slashes, and splitting drops empty segments in
+// one pass, collapsing interior doubles as part of the same normalisation.
+const trimmedSiteBase = (process.env.VITE_SITE_BASE || '/').split('/').filter(Boolean).join('/');
 const siteBase = `/${trimmedSiteBase}/`.replace('//', '/');
 const assetPrefix = `${siteBase}assets/`;
 

--- a/src/components/__tests__/data-display.test.ts
+++ b/src/components/__tests__/data-display.test.ts
@@ -711,15 +711,15 @@ describe('e-meter', () => {
     expect(el.getAttribute('role')).toBe('meter');
     expect(el.getAttribute('aria-valuenow')).toBe('72');
     expect(el.getAttribute('aria-valuetext')).toBe('72%');
-    expect(el.querySelectorAll('.ink-meter__segment').length).toBe(10);
-    expect(el.querySelectorAll('.ink-meter__segment[data-on]').length).toBe(7);
+    expect(el.querySelectorAll('.ink-meter__segment')).toHaveLength(10);
+    expect(el.querySelectorAll('.ink-meter__segment[data-on]')).toHaveLength(7);
   });
 
   it('clamps the visual and semantic value to the configured range', () => {
     const el = mount(`<e-meter min="10" max="20" value="50" segments="5"></e-meter>`);
     expect(el.getAttribute('aria-valuenow')).toBe('20');
     expect(el.getAttribute('aria-label')).toBe('Meter');
-    expect(el.querySelectorAll('.ink-meter__segment[data-on]').length).toBe(5);
+    expect(el.querySelectorAll('.ink-meter__segment[data-on]')).toHaveLength(5);
   });
 
   it('updates value and threshold band without replacing segments', () => {
@@ -777,7 +777,7 @@ describe('e-status-board', () => {
   it('renders keyed KPI cells with visible status words', () => {
     const el = mount(`<e-status-board data='${DATA}' columns="2"></e-status-board>`);
     expect(el.getAttribute('role')).toBe('region');
-    expect(el.querySelectorAll('[role="listitem"]').length).toBe(2);
+    expect(el.querySelectorAll('[role="listitem"]')).toHaveLength(2);
     expect(el.querySelector('[data-key="queue"] .ink-status-board__cue')!.textContent).toContain(
       'Warning',
     );

--- a/src/components/alert.ts
+++ b/src/components/alert.ts
@@ -143,7 +143,7 @@ export class EAlert extends HTMLElement {
     this._headingEl.hidden = heading === '';
   }
 
-  private _onClose = (): void => {
+  private readonly _onClose = (): void => {
     const value = this.getAttribute('heading') || (this._bodyEl?.textContent ?? '').trim();
     this.hidden = true;
     this.dispatchEvent(new CustomEvent('e-close', { detail: { value }, bubbles: true }));

--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -73,7 +73,7 @@ export class EAnchor extends HTMLElement {
     runCleanups(this);
   }
 
-  private _requestUpdate = (): void => {
+  private readonly _requestUpdate = (): void => {
     if (this._scrollFrame != null) return;
     this._scrollFrame = requestAnimationFrame(() => {
       this._scrollFrame = null;
@@ -81,7 +81,7 @@ export class EAnchor extends HTMLElement {
     });
   };
 
-  private _updateActive = (): void => {
+  private readonly _updateActive = (): void => {
     const links = [...this.querySelectorAll<HTMLAnchorElement>('.ink-anchor__link')];
     const offsetTop = Math.max(0, numAttr(this, 'offset-top', 80));
     let active = this._items[0]?.href;

--- a/src/components/avatar.ts
+++ b/src/components/avatar.ts
@@ -77,7 +77,7 @@ export class EAvatar extends HTMLElement {
     }
   }
 
-  private _onImageError = (): void => {
+  private readonly _onImageError = (): void => {
     this._failedSrc = this.getAttribute('src');
     this._render();
   };

--- a/src/components/back-top.ts
+++ b/src/components/back-top.ts
@@ -88,7 +88,7 @@ export class EBackTop extends HTMLElement {
     }
   }
 
-  private _onClick = (): void => {
+  private readonly _onClick = (): void => {
     const y = this._scrollY();
     if (this._scrollTarget === window) window.scrollTo({ top: 0 });
     else (this._scrollTarget as HTMLElement).scrollTop = 0;
@@ -106,7 +106,7 @@ export class EBackTop extends HTMLElement {
     return t === window ? window.scrollY : (t as HTMLElement).scrollTop;
   }
 
-  private _update = (): void => {
+  private readonly _update = (): void => {
     if (!this._btn) return;
     const threshold = Math.max(0, numAttr(this, 'visibility-height', 400));
     const visible = this._scrollY() >= threshold;

--- a/src/components/calendar.ts
+++ b/src/components/calendar.ts
@@ -93,7 +93,7 @@ export class ECalendar extends HTMLElement {
     }
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const target = e.target as Element;
 
     const stepBtn = target.closest<HTMLElement>('[data-step]');
@@ -123,7 +123,7 @@ export class ECalendar extends HTMLElement {
     }
   };
 
-  private _onKeydown = (e: KeyboardEvent): void => {
+  private readonly _onKeydown = (e: KeyboardEvent): void => {
     const cell = (e.target as Element).closest<HTMLButtonElement>('.ink-calendar__cell');
     if (!cell || cell.disabled || !this.contains(cell)) return;
     const day = Number(cell.dataset['day']);

--- a/src/components/cascader.ts
+++ b/src/components/cascader.ts
@@ -186,14 +186,14 @@ export class ECascader extends BaseFormControl {
     });
   }
 
-  private _onTriggerClick = (): void => {
+  private readonly _onTriggerClick = (): void => {
     const open = this._menu.hidden;
     this._menu.hidden = !open;
     this._trigger.setAttribute('aria-expanded', String(open));
     if (open) this._focusColumn(this._menu.children.length - 1);
   };
 
-  private _onTriggerKeydown = (e: KeyboardEvent): void => {
+  private readonly _onTriggerKeydown = (e: KeyboardEvent): void => {
     if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       if (this._menu.hidden) {
@@ -213,7 +213,7 @@ export class ECascader extends BaseFormControl {
     (sel ?? items[0])?.focus();
   }
 
-  private _onMenuKeydown = (e: KeyboardEvent): void => {
+  private readonly _onMenuKeydown = (e: KeyboardEvent): void => {
     const item = (e.target as Element).closest<HTMLElement>('.ink-cascader__item');
     if (!item) return;
     const level = Number(item.dataset['level']);
@@ -254,7 +254,7 @@ export class ECascader extends BaseFormControl {
     }
   };
 
-  private _onMenuClick = (e: Event): void => {
+  private readonly _onMenuClick = (e: Event): void => {
     const item = (e.target as Element).closest<HTMLElement>('.ink-cascader__item');
     if (!item) return;
     const level = Number(item.dataset['level']);

--- a/src/components/change-marker.ts
+++ b/src/components/change-marker.ts
@@ -24,7 +24,7 @@ type ChangeDirection = 'up' | 'down' | 'changed' | 'unchanged';
  * <e-change-marker label="Temperature" previous="21.8" value="22.4" suffix=" °C" precision="1"></e-change-marker>
  */
 export class EChangeMarker extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'value',
     'previous',
     'label',
@@ -99,8 +99,11 @@ export class EChangeMarker extends HTMLElement {
     const showPrevious = this.hasAttribute('show-previous') && previous != null;
     const prefix = this.getAttribute('prefix') || '';
     const suffix = this.getAttribute('suffix') || '';
+    // Hoisted out of both return templates: nesting a conditional template inside
+    // another is the shape Sonar flags, and both branches built it identically.
+    const fromPrevious = showPrevious ? ` from ${prefix}${this._format(previous!)}${suffix}` : '';
     if (direction === 'changed') {
-      return `≠ Changed${showPrevious ? ` from ${prefix}${this._format(previous!)}${suffix}` : ''}`;
+      return `≠ Changed${fromPrevious}`;
     }
     const delta = Number(value) - Number(previous);
     const formattedDelta =
@@ -109,7 +112,7 @@ export class EChangeMarker extends HTMLElement {
         : Math.abs(delta).toFixed(this._precision()!);
     const word = direction === 'up' ? 'Increased' : 'Decreased';
     const symbol = direction === 'up' ? '▲' : '▼';
-    return `${symbol} ${word} by ${formattedDelta}${suffix}${showPrevious ? ` from ${prefix}${this._format(previous!)}${suffix}` : ''}`;
+    return `${symbol} ${word} by ${formattedDelta}${suffix}${fromPrevious}`;
   }
 
   private _patch(): void {
@@ -131,11 +134,9 @@ export class EChangeMarker extends HTMLElement {
     patchAttr(this._cueEl, 'hidden', cue ? null : '');
     patchAttr(this, 'role', this.hasAttribute('announce') ? 'status' : 'group');
     patchAttr(this, 'aria-live', this.hasAttribute('announce') ? 'polite' : null);
-    patchAttr(
-      this,
-      'aria-label',
-      `${label ? `${label}: ` : ''}${value}${cue ? `; ${cue}` : '; unchanged'}`,
-    );
+    const labelPrefix = label ? `${label}: ` : '';
+    const cueSuffix = cue ? `; ${cue}` : '; unchanged';
+    patchAttr(this, 'aria-label', `${labelPrefix}${value}${cueSuffix}`);
   }
 }
 

--- a/src/components/checkbox-group.ts
+++ b/src/components/checkbox-group.ts
@@ -59,7 +59,7 @@ export class ECheckboxGroup extends BaseFormControl {
     runCleanups(this);
   }
 
-  private _onChange = (): void => {
+  private readonly _onChange = (): void => {
     const v = [...this.querySelectorAll<HTMLInputElement>('input:checked')].map((i) => i.value);
     this._value = v.join(',');
     this.setAttribute('value', this._value);

--- a/src/components/chip.ts
+++ b/src/components/chip.ts
@@ -53,7 +53,7 @@ export class EChip extends HTMLElement {
     patchBoolAttr(btn, 'disabled', disabled);
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     if (boolAttr(this, 'disabled')) {
       e.stopImmediatePropagation();
       return;

--- a/src/components/collapse.ts
+++ b/src/components/collapse.ts
@@ -183,12 +183,12 @@ export class ECollapse extends HTMLElement {
   }
 
   /** A `<summary>` has no disabled state of its own — cancel the default. */
-  private _onClick = (e: MouseEvent): void => {
+  private readonly _onClick = (e: MouseEvent): void => {
     const summary = (e.target as Element).closest<HTMLElement>('.ink-collapse__summary');
     if (summary?.getAttribute('aria-disabled') === 'true') e.preventDefault();
   };
 
-  private _onToggle = (e: Event): void => {
+  private readonly _onToggle = (e: Event): void => {
     const details = e.target as HTMLDetailsElement;
     if (this._suppressed.delete(details)) return;
 

--- a/src/components/date-picker.ts
+++ b/src/components/date-picker.ts
@@ -90,7 +90,7 @@ export class EDatePicker extends BaseFormControl {
     runCleanups(this);
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const target = e.target as Element;
 
     /* Trigger toggle */
@@ -132,7 +132,7 @@ export class EDatePicker extends BaseFormControl {
     }
   };
 
-  private _onKeydown = (e: Event): void => {
+  private readonly _onKeydown = (e: Event): void => {
     const ke = e as KeyboardEvent;
     const target = ke.target as Element;
 
@@ -143,7 +143,7 @@ export class EDatePicker extends BaseFormControl {
     if (!cell || !this._pop || this._pop.hidden) return;
 
     const focusables = this._cells.filter((b) => !b.disabled);
-    if (focusables.indexOf(cell) < 0) return;
+    if (!focusables.includes(cell)) return;
 
     this._handleGridKeydown(ke, cell);
   };

--- a/src/components/dialog.ts
+++ b/src/components/dialog.ts
@@ -143,7 +143,7 @@ export class EDialog extends HTMLElement {
       this._syncHeaderVisibility();
       this._syncLabel();
     } else if (name === 'size') {
-      this._dialog?.setAttribute('data-size', this._size());
+      if (this._dialog) this._dialog.dataset.size = this._size();
     } else if (name === 'no-close') {
       this._syncHeaderVisibility();
     } else if (name === 'aria-label') {
@@ -178,7 +178,7 @@ export class EDialog extends HTMLElement {
 
     const dialog = document.createElement('dialog');
     dialog.className = 'ink-dialog';
-    dialog.setAttribute('data-size', this._size());
+    dialog.dataset.size = this._size();
     dialog.innerHTML = `<header class="ink-dialog__header">
         <h2 class="ink-dialog__title" id="${esc(titleId)}">${esc(heading)}</h2>
         <button type="button" class="ink-dialog__close" aria-label="Close">${iconSvg('close', 18)}</button>
@@ -234,7 +234,7 @@ export class EDialog extends HTMLElement {
   }
 
   /** `Escape` reaches the native element as `cancel`; veto it when static. */
-  private _onCancel = (e: Event): void => {
+  private readonly _onCancel = (e: Event): void => {
     if (boolAttr(this, 'static')) {
       e.preventDefault();
       return;
@@ -242,7 +242,7 @@ export class EDialog extends HTMLElement {
     this._reason = 'escape';
   };
 
-  private _onClick = (e: MouseEvent): void => {
+  private readonly _onClick = (e: MouseEvent): void => {
     const dialog = this._dialog;
     if (!dialog) return;
     const target = e.target as Element;
@@ -275,7 +275,7 @@ export class EDialog extends HTMLElement {
    * runs after a close we initiated ourselves — by then the attribute is
    * already gone and removing it again is a no-op that fires nothing.
    */
-  private _onNativeClose = (): void => {
+  private readonly _onNativeClose = (): void => {
     this._modal = false;
     if (this._suppressNativeClose > 0) {
       this._suppressNativeClose -= 1;

--- a/src/components/diff.ts
+++ b/src/components/diff.ts
@@ -19,7 +19,7 @@ import { define, patchAttr, patchText } from '../core/dom';
  * <e-diff label="Firmware" before="1.8.4" after="1.9.0"></e-diff>
  */
 export class EDiff extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'before',
     'after',
     'label',

--- a/src/components/divider.ts
+++ b/src/components/divider.ts
@@ -12,7 +12,7 @@ import { define, esc, patchAttr, patchText } from '../core/dom';
  * <e-divider variant="dashed" label="OR"></e-divider>
  */
 export class EDivider extends HTMLElement {
-  static observedAttributes = ['variant', 'orientation', 'label'];
+  static readonly observedAttributes = ['variant', 'orientation', 'label'];
 
   private _wired = false;
   private _inner: Element | null = null;

--- a/src/components/dropdown.ts
+++ b/src/components/dropdown.ts
@@ -27,7 +27,7 @@ type DropdownItemDef =
  * </e-dropdown>
  */
 export class EDropdown extends HTMLElement {
-  static observedAttributes = ['align'];
+  static readonly observedAttributes = ['align'];
 
   private _wired = false;
   private _menu: HTMLElement | null = null;
@@ -165,9 +165,9 @@ export class EDropdown extends HTMLElement {
     items[((index % items.length) + items.length) % items.length]?.focus();
   }
 
-  private _onTriggerClick = (): void => this._setOpen(!!this._menu?.hidden);
+  private readonly _onTriggerClick = (): void => this._setOpen(!!this._menu?.hidden);
 
-  private _onTriggerKeydown = (e: KeyboardEvent): void => {
+  private readonly _onTriggerKeydown = (e: KeyboardEvent): void => {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     e.preventDefault();
     this._setOpen(true);
@@ -175,7 +175,7 @@ export class EDropdown extends HTMLElement {
     this._focusItem(e.key === 'ArrowDown' ? 0 : items.length - 1);
   };
 
-  private _onMenuClick = (e: Event): void => {
+  private readonly _onMenuClick = (e: Event): void => {
     const item = (e.target as Element).closest<HTMLButtonElement>('.ink-dropdown__item');
     if (!item || item.disabled || !this._menu?.contains(item)) return;
     const menuItems = [...this._menu.querySelectorAll('.ink-dropdown__item')];
@@ -189,7 +189,7 @@ export class EDropdown extends HTMLElement {
     this._triggerControl()?.focus();
   };
 
-  private _onMenuKeydown = (e: KeyboardEvent): void => {
+  private readonly _onMenuKeydown = (e: KeyboardEvent): void => {
     if (this._menu?.hidden) return;
     const items = this._enabledItems();
     const current = items.indexOf(document.activeElement as HTMLButtonElement);

--- a/src/components/empty.ts
+++ b/src/components/empty.ts
@@ -19,7 +19,7 @@ import { iconSvg } from '../core/icons';
  * </e-empty>
  */
 export class EEmpty extends HTMLElement {
-  static observedAttributes = ['icon', 'title', 'description'];
+  static readonly observedAttributes = ['icon', 'title', 'description'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;
@@ -57,22 +57,30 @@ export class EEmpty extends HTMLElement {
     } else if (name === 'title' && this._titleEl) {
       patchText(this._titleEl, this.getAttribute('title') || 'No data');
     } else if (name === 'description') {
-      const desc = this.getAttribute('description') || '';
-      if (desc && !this._descEl) {
-        const el = document.createElement('div');
-        el.className = 'ink-empty__desc';
-        el.textContent = desc;
-        if (this._actionWrap) this._root.insertBefore(el, this._actionWrap);
-        else this._root.appendChild(el);
-        this._descEl = el;
-      } else if (desc && this._descEl) {
-        patchText(this._descEl, desc);
-      } else if (!desc && this._descEl) {
-        this._descEl.remove();
-        this._descEl = null;
-      }
-      patchAttr(this._root, 'data-has-desc', desc ? '' : null);
+      this._syncDescription(this.getAttribute('description') || '');
     }
+  }
+
+  /**
+   * Create, update or drop the description element to match `desc`. Split out of
+   * `attributeChangedCallback` so neither carries the branching of both.
+   */
+  private _syncDescription(desc: string): void {
+    if (!this._root) return;
+    if (!desc) {
+      this._descEl?.remove();
+      this._descEl = null;
+    } else if (this._descEl) {
+      patchText(this._descEl, desc);
+    } else {
+      const el = document.createElement('div');
+      el.className = 'ink-empty__desc';
+      el.textContent = desc;
+      if (this._actionWrap) this._root.insertBefore(el, this._actionWrap);
+      else this._root.appendChild(el);
+      this._descEl = el;
+    }
+    patchAttr(this._root, 'data-has-desc', desc ? '' : null);
   }
 }
 

--- a/src/components/flex.ts
+++ b/src/components/flex.ts
@@ -15,7 +15,7 @@ import { boolAttr, define } from '../core/dom';
  * <e-flex direction="row" gap="8" align="center"><span>A</span><span>B</span></e-flex>
  */
 export class EFlex extends HTMLElement {
-  static observedAttributes = ['direction', 'wrap', 'justify', 'align', 'gap', 'inline'];
+  static readonly observedAttributes = ['direction', 'wrap', 'justify', 'align', 'gap', 'inline'];
 
   connectedCallback() {
     this._render();
@@ -37,7 +37,7 @@ export class EFlex extends HTMLElement {
     if (this.style.flexWrap !== wrap) this.style.flexWrap = wrap;
     if (this.style.justifyContent !== justify) this.style.justifyContent = justify;
     if (this.style.alignItems !== align) this.style.alignItems = align;
-    const gapVal = isNaN(+gap) ? gap : `${gap}px`;
+    const gapVal = Number.isNaN(+gap) ? gap : `${gap}px`;
     if (this.style.gap !== gapVal) this.style.gap = gapVal;
   }
 }

--- a/src/components/float-button.ts
+++ b/src/components/float-button.ts
@@ -13,7 +13,7 @@ import { iconSvg } from '../core/icons';
  * <e-float-button icon="plus" label="Add"></e-float-button>
  */
 export class EFloatButton extends HTMLElement {
-  static observedAttributes = ['icon', 'label', 'primary'];
+  static readonly observedAttributes = ['icon', 'label', 'primary'];
 
   private _wired = false;
   private _btn: HTMLButtonElement | null = null;
@@ -74,7 +74,7 @@ define('e-float-button', EFloatButton);
  * </e-float-button-group>
  */
 export class EFloatButtonGroup extends HTMLElement {
-  static observedAttributes = ['orientation'];
+  static readonly observedAttributes = ['orientation'];
 
   private _wired = false;
   private _group: HTMLElement | null = null;

--- a/src/components/form.ts
+++ b/src/components/form.ts
@@ -15,7 +15,7 @@ import { boolAttr, define, patchText, randId } from '../core/dom';
  * </e-form>
  */
 export class EForm extends HTMLElement {
-  static observedAttributes = ['layout'];
+  static readonly observedAttributes = ['layout'];
 
   private _form: HTMLFormElement | null = null;
 
@@ -55,7 +55,7 @@ define('e-form', EForm);
  * @attr {string} [required-label='REQ'] - Text shown inside the required pill.
  */
 export class EFormItem extends HTMLElement {
-  static observedAttributes = ['label', 'hint', 'error', 'required', 'required-label'];
+  static readonly observedAttributes = ['label', 'hint', 'error', 'required', 'required-label'];
 
   private _root: HTMLElement | null = null;
   private _control: HTMLElement | null = null;
@@ -69,7 +69,7 @@ export class EFormItem extends HTMLElement {
   connectedCallback() {
     if (!this._root) {
       const controlWrap = document.createElement('div');
-      controlWrap.setAttribute('data-control', '');
+      controlWrap.dataset.control = '';
       while (this.firstChild) controlWrap.appendChild(this.firstChild);
       const root = document.createElement('div');
       root.className = 'ink-form-item';
@@ -87,69 +87,86 @@ export class EFormItem extends HTMLElement {
 
   private _render(): void {
     const root = this._root!;
-    const control = this._control!;
     const label = this.getAttribute('label');
     const hint = this.getAttribute('hint');
     const error = this.getAttribute('error');
     const required = boolAttr(this, 'required');
-    const requiredLabel = this.getAttribute('required-label') || 'REQ';
 
-    if (label) {
-      if (!this._labelEl) {
-        this._labelEl = document.createElement('label');
-        this._labelEl.className = 'ink-form-item__label';
-        this._labelEl.appendChild(document.createTextNode(label));
-        root.insertBefore(this._labelEl, control);
-      } else {
-        const txt = this._labelEl.firstChild;
-        if (txt?.nodeType === Node.TEXT_NODE) patchText(txt, label);
-      }
-      if (required) {
-        if (!this._requiredPill) {
-          const pill = document.createElement('span');
-          pill.className = 'ink-form-item__required';
-          pill.setAttribute('aria-label', 'required');
-          pill.textContent = requiredLabel;
-          this._labelEl.appendChild(pill);
-          this._requiredPill = pill;
-        } else {
-          patchText(this._requiredPill, requiredLabel);
-        }
-      } else if (this._requiredPill) {
-        this._requiredPill.remove();
-        this._requiredPill = null;
-      }
-    } else if (this._labelEl) {
-      this._labelEl.remove();
+    // One sync method per slot. Inlining all four kept `_render` above the
+    // cognitive-complexity budget while each block is independently simple.
+    this._syncLabel(root, label, required);
+    this._syncHint(root, hint, error);
+    this._syncError(root, error);
+    this._syncControlSemantics(label, required, error);
+  }
+
+  /** Create, update or drop the label element (and its required pill). */
+  private _syncLabel(root: HTMLElement, label: string | null, required: boolean): void {
+    if (!label) {
+      this._labelEl?.remove();
       this._labelEl = null;
       this._requiredPill = null;
+      return;
     }
+    if (this._labelEl) {
+      const txt = this._labelEl.firstChild;
+      if (txt?.nodeType === Node.TEXT_NODE) patchText(txt, label);
+    } else {
+      this._labelEl = document.createElement('label');
+      this._labelEl.className = 'ink-form-item__label';
+      this._labelEl.appendChild(document.createTextNode(label));
+      root.insertBefore(this._labelEl, this._control!);
+    }
+    this._syncRequiredPill(required);
+  }
 
-    if (hint && !error) {
-      if (!this._hintEl) {
-        this._hintEl = document.createElement('div');
-        this._hintEl.className = 'ink-hint';
-        root.appendChild(this._hintEl);
-      }
-      this._hintEl.textContent = hint;
-    } else if (this._hintEl) {
-      this._hintEl.remove();
+  /** Keep the "REQ" pill inside an existing label in step with `required`. */
+  private _syncRequiredPill(required: boolean): void {
+    if (!required) {
+      this._requiredPill?.remove();
+      this._requiredPill = null;
+      return;
+    }
+    const requiredLabel = this.getAttribute('required-label') || 'REQ';
+    if (this._requiredPill) {
+      patchText(this._requiredPill, requiredLabel);
+      return;
+    }
+    const pill = document.createElement('span');
+    pill.className = 'ink-form-item__required';
+    pill.setAttribute('aria-label', 'required');
+    pill.textContent = requiredLabel;
+    this._labelEl!.appendChild(pill);
+    this._requiredPill = pill;
+  }
+
+  /** The hint is suppressed while an error is showing. */
+  private _syncHint(root: HTMLElement, hint: string | null, error: string | null): void {
+    if (!hint || error) {
+      this._hintEl?.remove();
       this._hintEl = null;
+      return;
     }
+    if (!this._hintEl) {
+      this._hintEl = document.createElement('div');
+      this._hintEl.className = 'ink-hint';
+      root.appendChild(this._hintEl);
+    }
+    this._hintEl.textContent = hint;
+  }
 
-    if (error) {
-      if (!this._errorEl) {
-        this._errorEl = document.createElement('div');
-        this._errorEl.className = 'ink-error';
-        root.appendChild(this._errorEl);
-      }
-      this._errorEl.textContent = `! ${error}`;
-    } else if (this._errorEl) {
-      this._errorEl.remove();
+  private _syncError(root: HTMLElement, error: string | null): void {
+    if (!error) {
+      this._errorEl?.remove();
       this._errorEl = null;
+      return;
     }
-
-    this._syncControlSemantics(label, required, error);
+    if (!this._errorEl) {
+      this._errorEl = document.createElement('div');
+      this._errorEl.className = 'ink-error';
+      root.appendChild(this._errorEl);
+    }
+    this._errorEl.textContent = `! ${error}`;
   }
 
   private _syncControlSemantics(

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -14,7 +14,7 @@ import { define } from '../core/dom';
  * </e-grid>
  */
 export class EGrid extends HTMLElement {
-  static observedAttributes = ['cols', 'gap'];
+  static readonly observedAttributes = ['cols', 'gap'];
 
   connectedCallback() {
     this._render();
@@ -27,8 +27,8 @@ export class EGrid extends HTMLElement {
   private _render(): void {
     const cols = this.getAttribute('cols') || '12';
     const gap = this.getAttribute('gap') || '0';
-    const cssCols = isNaN(+cols) ? cols : `repeat(${cols}, minmax(0, 1fr))`;
-    const cssGap = isNaN(+gap) ? gap : `${gap}px`;
+    const cssCols = Number.isNaN(+cols) ? cols : `repeat(${cols}, minmax(0, 1fr))`;
+    const cssGap = Number.isNaN(+gap) ? gap : `${gap}px`;
     if (this.style.display !== 'grid') this.style.display = 'grid';
     if (this.style.gridTemplateColumns !== cssCols) this.style.gridTemplateColumns = cssCols;
     if (this.style.gap !== cssGap) this.style.gap = cssGap;
@@ -44,7 +44,7 @@ define('e-grid', EGrid);
  * @attr {string} [row] - `grid-row` value.
  */
 export class EGridItem extends HTMLElement {
-  static observedAttributes = ['col', 'row'];
+  static readonly observedAttributes = ['col', 'row'];
 
   connectedCallback() {
     this._render();

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -13,7 +13,7 @@ import { ICONS, iconSvg } from '../core/icons';
  * <e-icon name="plus" size="24" label="Add"></e-icon>
  */
 export class EIcon extends HTMLElement {
-  static observedAttributes = ['name', 'size', 'label'];
+  static readonly observedAttributes = ['name', 'size', 'label'];
 
   connectedCallback() {
     this._render();

--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -27,7 +27,7 @@ import { boolAttr, define, patchAttr, patchText } from '../core/dom';
  * <e-image src="/cover.jpg" alt="Cover" fallback="/cover.svg" caption="Issue #42"></e-image>
  */
 export class EImage extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'src',
     'alt',
     'fallback',
@@ -86,7 +86,7 @@ export class EImage extends HTMLElement {
     }
   }
 
-  private _onLoad = (): void => {
+  private readonly _onLoad = (): void => {
     if (!this._img) return;
     patchAttr(this._img, 'data-state', 'loaded');
     this._removePlaceholder();
@@ -100,7 +100,7 @@ export class EImage extends HTMLElement {
     );
   };
 
-  private _onError = (): void => {
+  private readonly _onError = (): void => {
     if (!this._img) return;
     const fallback = this.getAttribute('fallback');
     if (fallback && !this._triedFallback) {

--- a/src/components/input-number.ts
+++ b/src/components/input-number.ts
@@ -24,7 +24,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-input-number value="3" min="0" max="10" step="1"></e-input-number>
  */
 export class EInputNumber extends BaseFormControl<string> {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'value',
     'min',
     'max',
@@ -157,7 +157,7 @@ export class EInputNumber extends BaseFormControl<string> {
     );
   }
 
-  private _stopHold = (): void => {
+  private readonly _stopHold = (): void => {
     if (this._holdDelay != null) {
       clearTimeout(this._holdDelay);
       this._holdDelay = null;
@@ -180,12 +180,12 @@ export class EInputNumber extends BaseFormControl<string> {
     else this._input.removeAttribute(name);
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const button = (e.target as Element).closest<HTMLElement>('[data-step]');
     if (button) this._step(Number(button.dataset['step']));
   };
 
-  private _onMouseDown = (e: MouseEvent): void => {
+  private readonly _onMouseDown = (e: MouseEvent): void => {
     const button = (e.target as Element).closest<HTMLElement>('[data-step]');
     if (!button) return;
     const direction = Number(button.dataset['step']);
@@ -195,7 +195,7 @@ export class EInputNumber extends BaseFormControl<string> {
     }, 400);
   };
 
-  private _onInputChange = (): void => {
+  private readonly _onInputChange = (): void => {
     if (!this._input) return;
     const value = this._input.value;
     this._value = value;
@@ -210,7 +210,7 @@ export class EInputNumber extends BaseFormControl<string> {
     );
   };
 
-  private _onInput = (): void => {
+  private readonly _onInput = (): void => {
     if (!this._input) return;
     this._value = this._input.value;
     this.internals.setFormValue(this._value);

--- a/src/components/input.ts
+++ b/src/components/input.ts
@@ -34,7 +34,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-input label="Name" placeholder="Ada Lovelace"></e-input>
  */
 export class EInput extends BaseFormControl {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'value',
     'error',
     'error-message',

--- a/src/components/kaleido.ts
+++ b/src/components/kaleido.ts
@@ -73,7 +73,7 @@ function paintDither(canvas: HTMLCanvasElement, hex: string, size: number, cell:
  * <e-kaleido cell="3"></e-kaleido>
  */
 export class EKaleido extends HTMLElement {
-  static observedAttributes = ['cell'];
+  static readonly observedAttributes = ['cell'];
 
   connectedCallback() {
     this._render();

--- a/src/components/last-updated.ts
+++ b/src/components/last-updated.ts
@@ -47,7 +47,7 @@ const relativeAge = (ageSeconds: number): string => {
  * <e-last-updated datetime="2026-08-17T14:00:00Z" stale-after="600"></e-last-updated>
  */
 export class ELastUpdated extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'datetime',
     'now',
     'stale-after',

--- a/src/components/layout.ts
+++ b/src/components/layout.ts
@@ -15,7 +15,7 @@ import { boolAttr, captureWrap, clampedNumAttr, define } from '../core/dom';
  * </e-layout>
  */
 export class ELayout extends HTMLElement {
-  static observedAttributes = ['has-sider'];
+  static readonly observedAttributes = ['has-sider'];
 
   connectedCallback() {
     this.classList.add('ink-layout');
@@ -49,7 +49,7 @@ define('e-layout-header', ELayoutHeader);
  * @attr {string} [width='220'] - Pixel width of the sider.
  */
 export class ELayoutSider extends HTMLElement {
-  static observedAttributes = ['width'];
+  static readonly observedAttributes = ['width'];
 
   private _aside: HTMLElement | null = null;
 

--- a/src/components/link.ts
+++ b/src/components/link.ts
@@ -12,7 +12,7 @@ import { captureWrap, define, patchAttr } from '../core/dom';
  * <e-link href="/about">About</e-link>
  */
 export class ELink extends HTMLElement {
-  static observedAttributes = ['href'];
+  static readonly observedAttributes = ['href'];
 
   private _a: HTMLAnchorElement | null = null;
 

--- a/src/components/list.ts
+++ b/src/components/list.ts
@@ -22,7 +22,7 @@ import { boolAttr, define, patchBoolAttr, patchText } from '../core/dom';
  * </e-list>
  */
 export class EList extends HTMLElement {
-  static observedAttributes = ['bordered', 'split', 'header-title'];
+  static readonly observedAttributes = ['bordered', 'split', 'header-title'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;
@@ -131,7 +131,7 @@ define('e-list', EList);
  * @slot trailing - Element rendered after the text (action, badge).
  */
 export class EListItem extends HTMLElement {
-  static observedAttributes = ['title', 'description'];
+  static readonly observedAttributes = ['title', 'description'];
 
   private _wired = false;
   private _row: HTMLElement | null = null;

--- a/src/components/masonry.ts
+++ b/src/components/masonry.ts
@@ -17,7 +17,7 @@ import { define, intAttr, numAttr } from '../core/dom';
  * </e-masonry>
  */
 export class EMasonry extends HTMLElement {
-  static observedAttributes = ['columns', 'gap'];
+  static readonly observedAttributes = ['columns', 'gap'];
 
   connectedCallback() {
     this.classList.add('ink-masonry');

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -45,11 +45,11 @@ interface RenderedItem {
  * </e-menu>
  */
 export class EMenu extends HTMLElement {
-  static observedAttributes = ['mode', 'value'];
+  static readonly observedAttributes = ['mode', 'value'];
 
   private _wired = false;
   private _items: MenuItem[] = [];
-  private _byValue = new Map<string, RenderedItem>();
+  private readonly _byValue = new Map<string, RenderedItem>();
   private _rootUl: HTMLUListElement | null = null;
 
   connectedCallback() {
@@ -74,7 +74,7 @@ export class EMenu extends HTMLElement {
     else if (name === 'mode') this._applyMode();
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const btn = (e.target as Element).closest<HTMLElement>('.ink-menu__btn');
     if (!btn || !this.contains(btn)) return;
     const v = btn.dataset['value'] ?? '';
@@ -89,7 +89,7 @@ export class EMenu extends HTMLElement {
     }
   };
 
-  private _onKeydown = (e: Event): void => {
+  private readonly _onKeydown = (e: Event): void => {
     const ke = e as KeyboardEvent;
     const btn = (ke.target as Element).closest<HTMLButtonElement>('.ink-menu__btn');
     if (!btn || !this.contains(btn)) return;

--- a/src/components/meter.ts
+++ b/src/components/meter.ts
@@ -23,7 +23,7 @@ type MeterBand = 'low' | 'normal' | 'high';
  * <e-meter label="Battery" value="72" low="20" high="90" unit="%"></e-meter>
  */
 export class EMeter extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'value',
     'min',
     'max',
@@ -39,7 +39,7 @@ export class EMeter extends HTMLElement {
   private _root: HTMLElement | null = null;
   private _labelEl: HTMLElement | null = null;
   private _scale: HTMLElement | null = null;
-  private _segments: HTMLElement[] = [];
+  private readonly _segments: HTMLElement[] = [];
   private _valueEl: HTMLElement | null = null;
   private _bandEl: HTMLElement | null = null;
 

--- a/src/components/pagination.ts
+++ b/src/components/pagination.ts
@@ -20,7 +20,7 @@ interface PageCell {
  * <e-pagination current="3" total="42" sibling-count="1"></e-pagination>
  */
 export class EPagination extends HTMLElement {
-  static observedAttributes = ['current', 'total', 'sibling-count'];
+  static readonly observedAttributes = ['current', 'total', 'sibling-count'];
 
   private _wired = false;
   private _nav: HTMLElement | null = null;
@@ -45,7 +45,7 @@ export class EPagination extends HTMLElement {
     if (this._wired) this._sync();
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const btn = (e.target as Element).closest<HTMLButtonElement>('[data-page]');
     if (!btn || btn.disabled || !this.contains(btn)) return;
     const p = Number(btn.dataset['page']);

--- a/src/components/popover.ts
+++ b/src/components/popover.ts
@@ -161,7 +161,7 @@ class Popup {
  * </e-popover>
  */
 export class EPopover extends HTMLElement {
-  static observedAttributes = ['align', 'placement', 'heading', 'open'];
+  static readonly observedAttributes = ['align', 'placement', 'heading', 'open'];
 
   private _wired = false;
   private _popup: Popup | null = null;
@@ -283,7 +283,7 @@ define('e-popover', EPopover);
  * </e-popconfirm>
  */
 export class EPopconfirm extends HTMLElement {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'message',
     'confirm-label',
     'cancel-label',
@@ -385,7 +385,7 @@ export class EPopconfirm extends HTMLElement {
     panel.classList.toggle('ink-popconfirm__panel--top', this.getAttribute('placement') === 'top');
   }
 
-  private _onPanelClick = (e: Event): void => {
+  private readonly _onPanelClick = (e: Event): void => {
     const action = (e.target as Element).closest<HTMLElement>('[data-action]');
     if (!action) return;
     this._resolve(action.dataset['action'] === 'confirm');

--- a/src/components/progress.ts
+++ b/src/components/progress.ts
@@ -18,7 +18,7 @@ import { define, intAttr, numAttr, patchAttr, patchBoolAttr, patchText } from '.
  * <e-progress value="42" label="Upload"></e-progress>
  */
 export class EProgress extends HTMLElement {
-  static observedAttributes = ['value', 'max', 'variant', 'steps', 'label', 'hide-label'];
+  static readonly observedAttributes = ['value', 'max', 'variant', 'steps', 'label', 'hide-label'];
 
   private _wired = false;
   private _variant: 'linear' | 'steps' | null = null;
@@ -88,7 +88,7 @@ export class EProgress extends HTMLElement {
       for (let i = 0; i < stepsCount; i++) {
         const seg = document.createElement('span');
         seg.className = 'ink-progress__seg';
-        if (i < filledSteps) seg.setAttribute('data-on', '');
+        if (i < filledSteps) seg.dataset.on = '';
         grid.appendChild(seg);
         this._segs.push(seg);
       }

--- a/src/components/qrcode.ts
+++ b/src/components/qrcode.ts
@@ -497,7 +497,7 @@ function qrToSvg(qr: QrCode, scale: number, border: number): string {
 type QrData = ReturnType<typeof encodeText>;
 
 export class EQrcode extends HTMLElement {
-  static observedAttributes = ['value', 'level', 'scale', 'border'];
+  static readonly observedAttributes = ['value', 'level', 'scale', 'border'];
 
   private _wired = false;
   private _wrap: HTMLElement | null = null;

--- a/src/components/radio-group.ts
+++ b/src/components/radio-group.ts
@@ -23,7 +23,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-radio-group>
  */
 export class ERadioGroup extends BaseFormControl {
-  static observedAttributes = ['value', 'layout', 'required', 'required-message'];
+  static readonly observedAttributes = ['value', 'layout', 'required', 'required-message'];
 
   private _wired = false;
 

--- a/src/components/result.ts
+++ b/src/components/result.ts
@@ -33,7 +33,7 @@ const isStatus = (s: string | null): s is Status =>
  * </e-result>
  */
 export class EResult extends HTMLElement {
-  static observedAttributes = ['status', 'title', 'description'];
+  static readonly observedAttributes = ['status', 'title', 'description'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;
@@ -68,7 +68,7 @@ export class EResult extends HTMLElement {
     if (!this._wired || !this._root) return;
     if (name === 'status') {
       const status = this._status();
-      this._root.setAttribute('data-status', status);
+      this._root.dataset.status = status;
       if (this._iconWrap) this._iconWrap.innerHTML = iconSvg(STATUS_ICON[status], 64);
     } else if (name === 'title' && this._titleEl) {
       patchText(this._titleEl, this.getAttribute('title') || '');

--- a/src/components/ribbon.ts
+++ b/src/components/ribbon.ts
@@ -12,7 +12,7 @@ import { captureWrap, define, patchText } from '../core/dom';
  * <e-ribbon text="NEW"><e-card title="Hello"></e-card></e-ribbon>
  */
 export class ERibbon extends HTMLElement {
-  static observedAttributes = ['text'];
+  static readonly observedAttributes = ['text'];
 
   private _wrap: HTMLElement | null = null;
   private _tag: HTMLElement | null = null;

--- a/src/components/segmented.ts
+++ b/src/components/segmented.ts
@@ -15,7 +15,7 @@ import { addCleanup, define, patchAttr, runCleanups } from '../core/dom';
  * </e-segmented>
  */
 export class ESegmented extends HTMLElement {
-  static observedAttributes = ['value'];
+  static readonly observedAttributes = ['value'];
 
   private _wired = false;
   private _buttons: HTMLButtonElement[] = [];
@@ -43,13 +43,13 @@ export class ESegmented extends HTMLElement {
     if (this._wired) this._syncSelection();
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const btn = (e.target as Element).closest<HTMLButtonElement>('.ink-segmented__btn');
     if (!btn || !this.contains(btn)) return;
     this._selectButton(btn);
   };
 
-  private _onKeydown = (e: KeyboardEvent): void => {
+  private readonly _onKeydown = (e: KeyboardEvent): void => {
     const btn = (e.target as Element).closest<HTMLButtonElement>('.ink-segmented__btn');
     if (!btn || !this.contains(btn)) return;
     const index = this._buttons.indexOf(btn);

--- a/src/components/select.ts
+++ b/src/components/select.ts
@@ -23,7 +23,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * </e-select>
  */
 export class ESelect extends BaseFormControl {
-  static observedAttributes = ['value', 'placeholder', 'required', 'required-message'];
+  static readonly observedAttributes = ['value', 'placeholder', 'required', 'required-message'];
 
   private _wired = false;
   private _trigger: HTMLElement | null = null;
@@ -127,9 +127,9 @@ export class ESelect extends BaseFormControl {
     this._trigger?.focus();
   }
 
-  private _onTriggerClick = (): void => this._setOpen(!!this._menu?.hidden);
+  private readonly _onTriggerClick = (): void => this._setOpen(!!this._menu?.hidden);
 
-  private _onTriggerKeydown = (e: KeyboardEvent): void => {
+  private readonly _onTriggerKeydown = (e: KeyboardEvent): void => {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     e.preventDefault();
     this._setOpen(true);
@@ -137,12 +137,12 @@ export class ESelect extends BaseFormControl {
     this._focusOption(current >= 0 ? current : e.key === 'ArrowDown' ? 0 : this._optEls.length - 1);
   };
 
-  private _onMenuClick = (e: Event): void => {
+  private readonly _onMenuClick = (e: Event): void => {
     const option = (e.target as Element).closest<HTMLElement>('.ink-select__option');
     if (option) this._selectOption(option.dataset['value'] ?? '');
   };
 
-  private _onMenuKeydown = (e: KeyboardEvent): void => {
+  private readonly _onMenuKeydown = (e: KeyboardEvent): void => {
     if (this._menu?.hidden) return;
     const current = this._optEls.indexOf(document.activeElement as HTMLElement);
     if (e.key === 'ArrowDown') this._focusOption(current < 0 ? 0 : current + 1);

--- a/src/components/skeleton.ts
+++ b/src/components/skeleton.ts
@@ -17,7 +17,7 @@ import { define, intAttr, patchAttr } from '../core/dom';
  * <e-skeleton shape="text" lines="3"></e-skeleton>
  */
 export class ESkeleton extends HTMLElement {
-  static observedAttributes = ['shape', 'lines', 'width', 'height'];
+  static readonly observedAttributes = ['shape', 'lines', 'width', 'height'];
 
   private _wired = false;
   private _wrap: HTMLElement | null = null;

--- a/src/components/space.ts
+++ b/src/components/space.ts
@@ -12,7 +12,7 @@ import { boolAttr, define, numAttr } from '../core/dom';
  * <e-space size="12" wrap><e-button>A</e-button><e-button>B</e-button></e-space>
  */
 export class ESpace extends HTMLElement {
-  static observedAttributes = ['size', 'direction', 'wrap'];
+  static readonly observedAttributes = ['size', 'direction', 'wrap'];
 
   connectedCallback() {
     this._render();

--- a/src/components/sparkline.ts
+++ b/src/components/sparkline.ts
@@ -33,7 +33,7 @@ const valuesFrom = (raw: string | null): number[] => {
  * <e-sparkline label="Requests" values="[12,18,15,24,28,31]"></e-sparkline>
  */
 export class ESparkline extends HTMLElement {
-  static observedAttributes = ['values', 'label', 'min', 'max', 'hide-caption'];
+  static readonly observedAttributes = ['values', 'label', 'min', 'max', 'hide-caption'];
 
   private _wired = false;
   private _root: HTMLElement | null = null;

--- a/src/components/splitter.ts
+++ b/src/components/splitter.ts
@@ -19,7 +19,7 @@ import { addCleanup, clampedNumAttr, define, onGlobal, patchAttr, runCleanups } 
  * </e-splitter>
  */
 export class ESplitter extends HTMLElement {
-  static observedAttributes = ['orientation', 'initial', 'min', 'max'];
+  static readonly observedAttributes = ['orientation', 'initial', 'min', 'max'];
 
   private _wired = false;
   private _pa: HTMLElement | null = null;
@@ -126,13 +126,13 @@ export class ESplitter extends HTMLElement {
     this._setPct(this._pct);
   }
 
-  private _onDown = (e: MouseEvent): void => {
+  private readonly _onDown = (e: MouseEvent): void => {
     if (e.button !== 0) return;
     this._dragging = true;
     e.preventDefault();
   };
 
-  private _onMove = (e: MouseEvent): void => {
+  private readonly _onMove = (e: MouseEvent): void => {
     if (!this._dragging || !this._wrap) return;
     const rect = this._wrap.getBoundingClientRect();
     if ((this._isH && rect.width === 0) || (!this._isH && rect.height === 0)) return;
@@ -148,11 +148,11 @@ export class ESplitter extends HTMLElement {
     });
   };
 
-  private _onUp = (): void => {
+  private readonly _onUp = (): void => {
     this._dragging = false;
   };
 
-  private _onKeydown = (e: KeyboardEvent): void => {
+  private readonly _onKeydown = (e: KeyboardEvent): void => {
     const decrement = this._isH ? e.key === 'ArrowLeft' : e.key === 'ArrowUp';
     const increment = this._isH ? e.key === 'ArrowRight' : e.key === 'ArrowDown';
     if (!decrement && !increment) return;

--- a/src/components/statistic.ts
+++ b/src/components/statistic.ts
@@ -21,7 +21,15 @@ import { clampedNumAttr, define, patchAttr, patchText } from '../core/dom';
  * <e-statistic label="Revenue" value="12480" prefix="$" trend="up" delta="8.4%"></e-statistic>
  */
 export class EStatistic extends HTMLElement {
-  static observedAttributes = ['label', 'value', 'prefix', 'suffix', 'precision', 'trend', 'delta'];
+  static readonly observedAttributes = [
+    'label',
+    'value',
+    'prefix',
+    'suffix',
+    'precision',
+    'trend',
+    'delta',
+  ];
 
   private _wired = false;
   private _root: HTMLElement | null = null;

--- a/src/components/status-board.ts
+++ b/src/components/status-board.ts
@@ -79,13 +79,13 @@ const STATUS_META: Record<StatusBoardStatus, { symbol: string; label: string }> 
  * <e-status-board data='[{"key":"queue","label":"Queue","value":12,"status":"warning"}]'></e-status-board>
  */
 export class EStatusBoard extends HTMLElement {
-  static observedAttributes = ['data', 'label', 'columns', 'empty-text', 'hide-label'];
+  static readonly observedAttributes = ['data', 'label', 'columns', 'empty-text', 'hide-label'];
 
   private _wired = false;
   private _heading: HTMLElement | null = null;
   private _grid: HTMLElement | null = null;
   private _empty: HTMLElement | null = null;
-  private _cells = new Map<string, StatusCell>();
+  private readonly _cells = new Map<string, StatusCell>();
 
   connectedCallback() {
     if (this._wired) return;

--- a/src/components/steps.ts
+++ b/src/components/steps.ts
@@ -16,7 +16,7 @@ import { iconSvg } from '../core/icons';
  * </e-steps>
  */
 export class ESteps extends HTMLElement {
-  static observedAttributes = ['current', 'orientation'];
+  static readonly observedAttributes = ['current', 'orientation'];
 
   private _wired = false;
   private _items: Array<{ title: string; desc: string }> = [];
@@ -68,8 +68,8 @@ export class ESteps extends HTMLElement {
 
       const li = document.createElement('li');
       li.className = 'ink-steps__item';
-      li.setAttribute('data-done', String(done));
-      li.setAttribute('data-active', String(active));
+      li.dataset.done = String(done);
+      li.dataset.active = String(active);
 
       const bubble = document.createElement('div');
       bubble.className = 'ink-steps__bubble';

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -78,7 +78,14 @@ const parseJson = <T>(s: string | null, fallback: T): T => {
  *   selectable></e-table>
  */
 export class ETable extends HTMLElement {
-  static observedAttributes = ['columns', 'data', 'selectable', 'selected', 'sort', 'empty-text'];
+  static readonly observedAttributes = [
+    'columns',
+    'data',
+    'selectable',
+    'selected',
+    'sort',
+    'empty-text',
+  ];
 
   private _wired = false;
   private _columns: ColumnDef[] = [];
@@ -163,7 +170,7 @@ export class ETable extends HTMLElement {
     return { key, dir };
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const sortBtn = (e.target as Element).closest<HTMLButtonElement>('[data-sort-key]');
     if (sortBtn && this.contains(sortBtn)) {
       const key = sortBtn.dataset['sortKey'] || '';
@@ -180,7 +187,7 @@ export class ETable extends HTMLElement {
     }
   };
 
-  private _onChange = (e: Event): void => {
+  private readonly _onChange = (e: Event): void => {
     const target = e.target as HTMLInputElement;
     if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') return;
     if (!this.contains(target)) return;
@@ -234,8 +241,8 @@ export class ETable extends HTMLElement {
     }
     for (let i = 0; i < this._rowEls.length; i++) {
       const sel = this._selected.has(i);
-      if (sel) this._rowEls[i].setAttribute('data-selected', '');
-      else this._rowEls[i].removeAttribute('data-selected');
+      if (sel) this._rowEls[i].dataset.selected = '';
+      else delete this._rowEls[i].dataset.selected;
       if (this._rowCbs[i]) this._rowCbs[i].checked = sel;
     }
   }
@@ -318,7 +325,7 @@ export class ETable extends HTMLElement {
     } else {
       this._rows.forEach((row, i) => {
         const tr = document.createElement('tr');
-        if (this._selected.has(i)) tr.setAttribute('data-selected', '');
+        if (this._selected.has(i)) tr.dataset.selected = '';
         if (selectable) {
           const td = document.createElement('td');
           td.className = 'ink-table__check';

--- a/src/components/tabs.ts
+++ b/src/components/tabs.ts
@@ -22,8 +22,8 @@ import './badge';
 export class ETabs extends HTMLElement {
   private _wired = false;
   private _active = '';
-  private _buttons = new Map<string, HTMLButtonElement>();
-  private _panels = new Map<string, HTMLElement>();
+  private readonly _buttons = new Map<string, HTMLButtonElement>();
+  private readonly _panels = new Map<string, HTMLElement>();
 
   connectedCallback() {
     if (!this._wired) {
@@ -134,12 +134,12 @@ export class ETabs extends HTMLElement {
     }
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const button = (e.target as Element).closest<HTMLButtonElement>('.ink-tabs__tab');
     if (button && this.contains(button)) this._activate(button.dataset['key'] ?? '', true);
   };
 
-  private _onKeydown = (e: KeyboardEvent): void => {
+  private readonly _onKeydown = (e: KeyboardEvent): void => {
     const button = (e.target as Element).closest<HTMLButtonElement>('.ink-tabs__tab');
     if (!button || !this.contains(button)) return;
     const buttons = [...this._buttons.values()];

--- a/src/components/tag.ts
+++ b/src/components/tag.ts
@@ -18,7 +18,7 @@ import { addCleanup, boolAttr, captureWrap, define, patchBoolAttr, runCleanups }
  * <e-tag closable>Draft</e-tag>
  */
 export class ETag extends HTMLElement {
-  static observedAttributes = ['closable', 'disabled'];
+  static readonly observedAttributes = ['closable', 'disabled'];
 
   private _wrap: HTMLElement | null = null;
   private _btn: HTMLButtonElement | null = null;
@@ -69,7 +69,7 @@ export class ETag extends HTMLElement {
 
   private _buttonBound = false;
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     if (boolAttr(this, 'disabled')) {
       e.stopImmediatePropagation();
       return;

--- a/src/components/text.ts
+++ b/src/components/text.ts
@@ -13,7 +13,7 @@ import { captureWrap, define, patchClassModifier } from '../core/dom';
  * <e-text kind="label" as="span">SECTION</e-text>
  */
 export class EText extends HTMLElement {
-  static observedAttributes = ['kind', 'as'];
+  static readonly observedAttributes = ['kind', 'as'];
 
   private _wrap: HTMLElement | null = null;
   private _tag = '';

--- a/src/components/textarea.ts
+++ b/src/components/textarea.ts
@@ -26,7 +26,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-textarea placeholder="Notes…"></e-textarea>
  */
 export class ETextarea extends BaseFormControl {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'value',
     'error',
     'error-message',

--- a/src/components/time-picker.ts
+++ b/src/components/time-picker.ts
@@ -20,7 +20,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-time-picker value="09:30"></e-time-picker>
  */
 export class ETimePicker extends BaseFormControl {
-  static observedAttributes = ['value', 'required', 'required-message'];
+  static readonly observedAttributes = ['value', 'required', 'required-message'];
 
   private _wired = false;
   private _hCell: HTMLElement | null = null;
@@ -153,12 +153,12 @@ export class ETimePicker extends BaseFormControl {
     this.dispatchEvent(new CustomEvent('e-change', { detail: { value }, bubbles: true }));
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     const button = (e.target as Element).closest<HTMLElement>('[data-axis]');
     if (button) this._step(button.dataset['axis'] as 'h' | 'm', Number(button.dataset['dir']));
   };
 
-  private _onKeydown = (e: KeyboardEvent): void => {
+  private readonly _onKeydown = (e: KeyboardEvent): void => {
     const cell = (e.target as Element).closest<HTMLElement>('[data-cell]');
     if (!cell) return;
     const axis = cell.dataset['cell'] as 'h' | 'm';

--- a/src/components/timeline.ts
+++ b/src/components/timeline.ts
@@ -19,7 +19,7 @@ import { define } from '../core/dom';
  * </e-timeline>
  */
 export class ETimeline extends HTMLElement {
-  static observedAttributes = ['time-position'];
+  static readonly observedAttributes = ['time-position'];
 
   private _wired = false;
   private _list: HTMLElement | null = null;

--- a/src/components/title.ts
+++ b/src/components/title.ts
@@ -12,7 +12,7 @@ import { define, numAttr } from '../core/dom';
  * <e-title level="2">Section heading</e-title>
  */
 export class ETitle extends HTMLElement {
-  static observedAttributes = ['level'];
+  static readonly observedAttributes = ['level'];
 
   private _wrap: HTMLElement | null = null;
   private _level = 0;

--- a/src/components/toggle.ts
+++ b/src/components/toggle.ts
@@ -21,7 +21,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-toggle checked label="Enable notifications"></e-toggle>
  */
 export class EToggle extends BaseFormControl {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'checked',
     'label',
     'disabled',

--- a/src/components/tree-select.ts
+++ b/src/components/tree-select.ts
@@ -23,10 +23,10 @@ import { TreeView, parseTreeAttr } from '../core/tree';
  * <e-tree-select data='[{"value":"a","label":"A","children":[{"value":"a1","label":"A1"}]}]' default-expanded="a"></e-tree-select>
  */
 export class ETreeSelect extends BaseFormControl {
-  static observedAttributes = ['value', 'data', 'options', 'required', 'required-message'];
+  static readonly observedAttributes = ['value', 'data', 'options', 'required', 'required-message'];
 
   private _built = false;
-  private _view = new TreeView(this, {
+  private readonly _view = new TreeView(this, {
     onActivate: (value) => this._selectValue(value),
   });
 
@@ -78,11 +78,11 @@ export class ETreeSelect extends BaseFormControl {
     }
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     this._view.handleClick(e);
   };
 
-  private _onKeydown = (e: Event): void => {
+  private readonly _onKeydown = (e: Event): void => {
     this._view.handleKeydown(e as KeyboardEvent);
   };
 

--- a/src/components/tree.ts
+++ b/src/components/tree.ts
@@ -38,7 +38,7 @@ type CheckState = 'true' | 'false' | 'mixed';
  * <e-tree checkable data='[{"value":"src","label":"src","children":[{"value":"a","label":"app.ts"}]}]' default-expanded="src"></e-tree>
  */
 export class ETree extends HTMLElement {
-  static observedAttributes = ['data', 'value', 'checked'];
+  static readonly observedAttributes = ['data', 'value', 'checked'];
 
   private _built = false;
   private _view: TreeView | null = null;
@@ -207,13 +207,13 @@ export class ETree extends HTMLElement {
     this.dispatchEvent(new CustomEvent('e-select', { detail: { value }, bubbles: true }));
   }
 
-  private _onClick = (e: Event): void => {
+  private readonly _onClick = (e: Event): void => {
     this._view?.handleClick(e);
     // Expanding materialises new rows; paint their check marks in the same turn.
     this._syncAllCheckMarks();
   };
 
-  private _onKeydown = (e: Event): void => {
+  private readonly _onKeydown = (e: Event): void => {
     this._view?.handleKeydown(e as KeyboardEvent);
     this._syncAllCheckMarks();
   };

--- a/src/components/upload.ts
+++ b/src/components/upload.ts
@@ -25,7 +25,7 @@ import { BaseFormControl } from '../core/base-form-control';
  * <e-upload accept=".pdf,.png" multiple name="docs"></e-upload>
  */
 export class EUpload extends BaseFormControl<File[]> {
-  static observedAttributes = [
+  static readonly observedAttributes = [
     'accept',
     'multiple',
     'max-size',
@@ -271,36 +271,36 @@ export class EUpload extends BaseFormControl<File[]> {
     );
   }
 
-  private _onDropClick = (e: Event): void => {
+  private readonly _onDropClick = (e: Event): void => {
     if (e.target !== this._input) this._input?.click();
   };
 
-  private _onDropKeydown = (e: KeyboardEvent): void => {
+  private readonly _onDropKeydown = (e: KeyboardEvent): void => {
     if (e.key !== 'Enter' && e.key !== ' ') return;
     e.preventDefault();
     this._input?.click();
   };
 
-  private _onDragOver = (e: DragEvent): void => {
+  private readonly _onDragOver = (e: DragEvent): void => {
     e.preventDefault();
     if (this._drop?.dataset['drag'] !== 'true' && this._drop) this._drop.dataset['drag'] = 'true';
   };
 
-  private _onDragLeave = (): void => {
+  private readonly _onDragLeave = (): void => {
     if (this._drop) this._drop.dataset['drag'] = 'false';
   };
 
-  private _onDrop = (e: DragEvent): void => {
+  private readonly _onDrop = (e: DragEvent): void => {
     e.preventDefault();
     if (this._drop) this._drop.dataset['drag'] = 'false';
     if (e.dataTransfer?.files) this._handleFiles(e.dataTransfer.files);
   };
 
-  private _onInputChange = (): void => {
+  private readonly _onInputChange = (): void => {
     if (this._input?.files) this._handleFiles(this._input.files);
   };
 
-  private _onListClick = (e: Event): void => {
+  private readonly _onListClick = (e: Event): void => {
     const remove = (e.target as Element).closest<HTMLElement>('[data-remove]');
     if (!remove || !this._list?.contains(remove)) return;
     const index = Number(remove.dataset['remove']);

--- a/src/components/watermark.ts
+++ b/src/components/watermark.ts
@@ -24,7 +24,14 @@ import { clampedNumAttr, define, esc } from '../core/dom';
  * </e-watermark>
  */
 export class EWatermark extends HTMLElement {
-  static observedAttributes = ['content', 'font-size', 'gap-x', 'gap-y', 'rotate', 'opacity'];
+  static readonly observedAttributes = [
+    'content',
+    'font-size',
+    'gap-x',
+    'gap-y',
+    'rotate',
+    'opacity',
+  ];
 
   private _wired = false;
   private _layer: HTMLElement | null = null;

--- a/src/core/base-form-control.ts
+++ b/src/core/base-form-control.ts
@@ -6,7 +6,7 @@
 // `formStateRestoreCallback` to turn a string back into `T`).
 
 export abstract class BaseFormControl<T = string> extends HTMLElement {
-  static formAssociated = true;
+  static readonly formAssociated = true;
 
   protected internals: ElementInternals;
   protected _value: T = '' as unknown as T;

--- a/src/stories/display/List.stories.ts
+++ b/src/stories/display/List.stories.ts
@@ -37,7 +37,7 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     expect(canvas.getByText('Annual report')).toBeInTheDocument();
     const items = canvasElement.querySelectorAll('e-list-item');
-    expect(items.length).toBe(3);
+    expect(items).toHaveLength(3);
   },
 };
 

--- a/src/stories/display/Meter.stories.ts
+++ b/src/stories/display/Meter.stories.ts
@@ -50,7 +50,7 @@ export const InRange: Story = {
     await checkA11y(canvasElement);
     const meter = canvasElement.querySelector('e-meter')!;
     expect(meter.getAttribute('role')).toBe('meter');
-    expect(meter.querySelectorAll('.ink-meter__segment[data-on]').length).toBe(7);
+    expect(meter.querySelectorAll('.ink-meter__segment[data-on]')).toHaveLength(7);
   },
 };
 

--- a/src/stories/display/Progress.stories.ts
+++ b/src/stories/display/Progress.stories.ts
@@ -52,9 +52,9 @@ export const Steps: Story = {
   args: { value: 3, max: 5, steps: 5, variant: 'steps', label: 'Onboarding' },
   play: async ({ canvasElement }) => {
     const segs = canvasElement.querySelectorAll('.ink-progress__seg');
-    expect(segs.length).toBe(5);
+    expect(segs).toHaveLength(5);
     const filled = canvasElement.querySelectorAll('.ink-progress__seg[data-on]');
-    expect(filled.length).toBe(3);
+    expect(filled).toHaveLength(3);
   },
 };
 

--- a/src/stories/display/Skeleton.stories.ts
+++ b/src/stories/display/Skeleton.stories.ts
@@ -46,7 +46,7 @@ export const TextLines: Story = {
   args: { shape: 'text', lines: 4 },
   play: async ({ canvasElement }) => {
     const lines = canvasElement.querySelectorAll('.ink-skeleton__line');
-    expect(lines.length).toBe(4);
+    expect(lines).toHaveLength(4);
   },
 };
 

--- a/src/stories/display/Table.stories.ts
+++ b/src/stories/display/Table.stories.ts
@@ -43,7 +43,7 @@ export const Default: Story = {
     await checkA11y(canvasElement);
     const canvas = within(canvasElement);
     expect(canvas.getByText('Anna König')).toBeInTheDocument();
-    expect(canvasElement.querySelectorAll('tbody tr').length).toBe(4);
+    expect(canvasElement.querySelectorAll('tbody tr')).toHaveLength(4);
   },
 };
 

--- a/src/stories/layout/Flex.stories.ts
+++ b/src/stories/layout/Flex.stories.ts
@@ -62,7 +62,7 @@ export const Row: Story = {
     expect(cs.display).toBe('flex');
     expect(cs.flexDirection).toBe('row');
     expect(cs.gap).toBe('12px');
-    expect(flex.children.length).toBe(3);
+    expect(flex.children).toHaveLength(3);
   },
 };
 

--- a/src/stories/layout/Layout.stories.ts
+++ b/src/stories/layout/Layout.stories.ts
@@ -59,7 +59,7 @@ export const WithSider: Story = {
   `,
   play: async ({ canvasElement }) => {
     const outers = canvasElement.querySelectorAll('e-layout.ink-layout--has-sider');
-    expect(outers.length).toBe(2);
+    expect(outers).toHaveLength(2);
     const sider = canvasElement.querySelector('aside.ink-layout__sider') as HTMLElement;
     expect(sider).toBeInTheDocument();
     expect(sider.style.width).toBe('200px');
@@ -103,9 +103,9 @@ export const Reconnect: Story = {
     const parent = root.parentNode as HTMLElement;
     parent.removeChild(root);
     parent.appendChild(root);
-    expect(root.querySelectorAll('header.ink-layout__header').length).toBe(1);
-    expect(root.querySelectorAll('main.ink-layout__content').length).toBe(1);
-    expect(root.querySelectorAll('footer.ink-layout__footer').length).toBe(1);
+    expect(root.querySelectorAll('header.ink-layout__header')).toHaveLength(1);
+    expect(root.querySelectorAll('main.ink-layout__content')).toHaveLength(1);
+    expect(root.querySelectorAll('footer.ink-layout__footer')).toHaveLength(1);
   },
 };
 

--- a/src/stories/navigation/Dropdown.stories.ts
+++ b/src/stories/navigation/Dropdown.stories.ts
@@ -92,13 +92,13 @@ export const Interactions: Story = {
     const items = [...menu.querySelectorAll<HTMLButtonElement>('.ink-dropdown__item')];
     const firstEnabled = items.find((it) => !it.disabled)!;
     await userEvent.click(firstEnabled);
-    expect(events.length).toBe(1);
+    expect(events).toHaveLength(1);
     expect(menu.hidden).toBe(true);
 
     await userEvent.click(triggerWrap);
     const disabled = menu.querySelector<HTMLButtonElement>('.ink-dropdown__item[disabled]')!;
     await userEvent.click(disabled);
-    expect(events.length).toBe(1);
+    expect(events).toHaveLength(1);
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(menu.hidden).toBe(true);

--- a/src/stories/navigation/Menu.stories.ts
+++ b/src/stories/navigation/Menu.stories.ts
@@ -43,7 +43,7 @@ export const Vertical: Story = {
     const ul = canvasElement.querySelector('ul.ink-menu') as HTMLElement;
     expect(ul.classList.contains('ink-menu--horizontal')).toBe(false);
     const topButtons = canvasElement.querySelectorAll('ul.ink-menu > li > .ink-menu__btn');
-    expect(topButtons.length).toBe(4);
+    expect(topButtons).toHaveLength(4);
     const active = canvasElement.querySelector(
       '.ink-menu__btn[aria-current="page"]',
     ) as HTMLElement;
@@ -94,7 +94,7 @@ export const WithBadge: Story = {
   play: async ({ canvasElement }) => {
     await checkA11y(canvasElement);
     const buttons = canvasElement.querySelectorAll('.ink-menu__btn');
-    expect(buttons.length).toBe(4);
+    expect(buttons).toHaveLength(4);
     expect(canvasElement.textContent).toContain('12');
     expect(canvasElement.textContent).toContain('Inbox');
   },

--- a/src/stories/navigation/Pagination.stories.ts
+++ b/src/stories/navigation/Pagination.stories.ts
@@ -73,7 +73,7 @@ export const ManyPages: Story = {
   play: async ({ canvasElement }) => {
     await checkA11y(canvasElement);
     const gaps = canvasElement.querySelectorAll('.ink-pagination__gap');
-    expect(gaps.length).toBe(2);
+    expect(gaps).toHaveLength(2);
     const pager = canvasElement.querySelector('e-pagination') as HTMLElement;
     let captured: number | null = null;
     pager.addEventListener(
@@ -103,7 +103,7 @@ export const WideSiblings: Story = {
 export const SmallTotal: Story = {
   args: { current: 2, total: 4, siblingCount: 1 },
   play: async ({ canvasElement }) => {
-    expect(canvasElement.querySelectorAll('.ink-pagination__gap').length).toBe(0);
+    expect(canvasElement.querySelectorAll('.ink-pagination__gap')).toHaveLength(0);
     for (const p of [1, 2, 3, 4]) {
       expect(canvasElement.querySelector(`button[data-page="${p}"]`)).toBeInTheDocument();
     }

--- a/src/stories/primitives/Ribbon.stories.ts
+++ b/src/stories/primitives/Ribbon.stories.ts
@@ -83,7 +83,7 @@ export const Reconnect: Story = {
     const parent = ribbon.parentNode as HTMLElement;
     parent.removeChild(ribbon);
     parent.appendChild(ribbon);
-    expect(ribbon.querySelectorAll('.ink-ribbon').length).toBe(1);
+    expect(ribbon.querySelectorAll('.ink-ribbon')).toHaveLength(1);
   },
   render: () => html`<e-ribbon text="X"><span>X</span></e-ribbon>`,
 };

--- a/src/stories/typography/Link.stories.ts
+++ b/src/stories/typography/Link.stories.ts
@@ -61,7 +61,7 @@ export const Reconnect: Story = {
     const parent = link.parentNode as HTMLElement;
     parent.removeChild(link);
     parent.appendChild(link);
-    expect(link.querySelectorAll('a').length).toBe(1);
+    expect(link.querySelectorAll('a')).toHaveLength(1);
   },
   render: () => html`<e-link href="/x">Move</e-link>`,
 };

--- a/src/stories/typography/Text.stories.ts
+++ b/src/stories/typography/Text.stories.ts
@@ -82,7 +82,7 @@ export const Reconnect: Story = {
     expect(wrapped).toBeTruthy();
     parent.removeChild(t);
     parent.appendChild(t);
-    expect(t.querySelectorAll('p').length).toBe(1);
+    expect(t.querySelectorAll('p')).toHaveLength(1);
   },
   render: () => html`<e-text kind="prose" as="p">hello</e-text>`,
 };

--- a/src/stories/typography/Title.stories.ts
+++ b/src/stories/typography/Title.stories.ts
@@ -91,7 +91,7 @@ export const ClampLevel: Story = {
     // level=99 clamps to 6, level=0 clamps to 1
     expect(canvasElement.querySelector('e-title[level="99"] h6')).toBeTruthy();
     expect(canvasElement.querySelector('e-title[level="0"] h1')).toBeTruthy();
-    expect(headings.length).toBe(2);
+    expect(headings).toHaveLength(2);
   },
   render: () => html`
     <div>
@@ -107,7 +107,7 @@ export const Reconnect: Story = {
     const parent = t.parentNode as HTMLElement;
     parent.removeChild(t);
     parent.appendChild(t);
-    expect(t.querySelectorAll('h2').length).toBe(1);
+    expect(t.querySelectorAll('h2')).toHaveLength(1);
   },
   render: () => html`<e-title level="2">Move me</e-title>`,
 };


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed — `CHANGELOG.md` under `[Unreleased] → Changed`; story play functions updated where the assertion rule fired
- [x] CSS output builds locally (`npm run build`)

Works through the SonarQube Cloud findings reported for `main`. Each rule is applied to **every** file it fires on rather than only the reported lines, so the same rule doesn't come straight back on the next analysis. No rendered output, public attribute, event or slot contract changes.

**Readonly members** (`S2933` / `prefer-readonly`) — `observedAttributes` and `formAssociated` declared `static readonly` in all 76 places; the 126 private fields only ever assigned in an initialiser (almost all bound event handlers) marked `readonly`. Compile-time only.

**Cognitive complexity** (`S3776`) — `EFormItem._render` (24) split into one sync method per slot (label, required pill, hint, error); `EEmpty.attributeChangedCallback` (19) moves its description branch into `_syncDescription`. Both rewrites are branch-for-branch equivalent.

**Regex and API smells** — `isNaN` → `Number.isNaN` (argument already numeric, so the coercion was inert), `indexOf(x) < 0` → `!includes(x)`, `setAttribute('data-*')` → `dataset` where equivalent, nested template literals hoisted into named locals, hoisted `RegExp.exec` in place of `String.match`, trivial single-character patterns passed as strings.

**ReDoS** (`S5852`) — `scripts/inline-site-css.mjs` drops `/\/+$/`, which backtracks super-linearly on a run of slashes, for a split/filter/join. Also fixes a latent bug: a base with interior double slashes used to yield a broken `/a//b/`.

**Path handling** (`S2083`) — `gen-pages-index.mjs` already refused to write outside the checkout. The guard is reduced to a single `startsWith(outRoot + sep)` on the canonicalised path — the containment shape the analyser recognises — dropping the redundant equality test, since the root itself is a directory.

**Test assertions** — all 26 `expect(x.length).toBe(n)` → `toHaveLength(n)`, in the data-display suite and the story play functions.

**Tooling** — `eslint.config.mjs` uses `defineConfig`/`globalIgnores` from `eslint/config`; typescript-eslint deprecated the `tseslint.config()` wrapper.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm run build` — 95 tags, 352 attributes across 92 elements in the manifest, so IDE autocomplete is intact
- [x] `npm run size` — barrel 39.75 kB / 40 kB
- [x] `npm run test:ci` — 629 passed

The 22 screenshot comparisons that fail in the dev container fail **identically on an unmodified `main`** in the same container (verified by stashing and re-running: same 22 names, ~0.01 pixel ratio). It runs Chromium 1194 against baselines captured in the pinned CI image. Every other test passes, including the form-association and reactivity suites that cover the `form.ts` refactor.

## Notes

Three findings are deliberately **not** fixed — each would require making the code worse to satisfy the rule. Suggest resolving them in the Sonar UI rather than in code:

1. **`checkbox.ts` L117** — *"Provide multiple methods instead of using `v` to determine which action to take"* (`S2301`). This is `set checked(v: boolean)`, a DOM property setter. Its signature is fixed by the `HTMLInputElement.checked` contract that `el.checked = true` depends on; a setter cannot be split into multiple methods. → **False positive, mark Won't Fix.**

2. **`float-button.ts` L82** — *"implementation is identical to the one on line 22"* (`S4144`). The duplicate is the guarded `connectedCallback` that `CLAUDE.md` mandates for every component. Deduplicating the two classes in this file needs a shared base class, which `CLAUDE.md` explicitly forbids ("components extend `HTMLElement` directly or `BaseFormControl<T>`"). → **Mark Won't Fix**, or relax the convention first.

3. **`release.yml` L229** — *"Using dependencies without locking resolved versions"*. This is the post-publish smoke test installing the just-released package from the registry. Both direct deps are already exact-pinned (`@$VERSION`, `jsdom@30.0.1`, `--save-exact`, `--ignore-scripts`); only transitives float, which is the point — the test verifies the published tarball installs the way a real consumer gets it. A lockfile can't exist beforehand because the version is minted at release time. → **Mark Safe.**

One thing worth a reviewer's eye: the `S2083` fix on `gen-pages-index.mjs` is a shape change to satisfy the taint analyser, and I could not confirm it clears the finding — **SonarCloud is unreachable from this session** (egress policy returns 403 on CONNECT to `sonarcloud.io`), so every finding here came from the list pasted into the session, and I could not re-run an analysis to confirm the gate. The findings list was also truncated partway through `src/components/icon.ts`; applying each rule repo-wide rather than line-by-line is what covers the unseen tail, but a fresh analysis is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142QkWiQkcosC2GkM1b3pno)_