### PR TITLE
ci: skip SonarQube analysis on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,18 @@ jobs:
             echo "::notice title=SonarQube::SONAR_TOKEN is not set — skipping analysis."
           fi
 
+      # release.yml calls this workflow again on the `v*` tag push, re-checking
+      # out the same commit that already went through this job on its `main`
+      # push. GITHUB_REF_NAME on a tag ref is the tag itself, so the scanner's
+      # CI auto-detection reports the analysis as branch `v1.1.0` (etc.)
+      # instead of `main`; SonarCloud only recognizes the configured main
+      # branch (and PRs) for this project, so the quality-gate read-back for
+      # that unknown branch is rejected after the upload — surfacing as
+      # "Not authorized or project not found" regardless of token validity.
+      # The commit was already analyzed under the right branch name, so skip
+      # the repeat run rather than re-analyze under a ref Sonar will reject.
       - name: SonarQube scan
-        if: steps.token.outputs.present == 'true'
+        if: steps.token.outputs.present == 'true' && github.ref_type != 'tag'
         # Pinned to a commit, not a tag: a mutable tag lets an upstream
         # compromise reach a runner that has SONAR_TOKEN. This is v8.2.1.
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [ ] Demo/story/docs updated if needed — not applicable, workflow-only change
- [ ] CSS output builds locally (`npm run build`) — not applicable, workflow-only change

The `v1.1.0` tag release failed at `Checks / SonarQube` with `Not authorized or project not found`, even though the exact same commit's SonarQube scan had just succeeded on the regular `main` push CI run — and it kept failing the same way after the `SONAR_TOKEN` repository secret was rotated, which ruled out a bad token.

Looking at the job log: the analysis report itself uploads successfully (`Analysis report uploaded in 931ms`) — auth is fine for that call. The failure happens right after, at the quality-gate read-back (`Waiting for the analysis report to be processed` → `ERROR Not authorized or project not found`).

The difference between the two runs is the git ref. `release.yml`'s `checks` stage re-invokes `ci.yml` again on the `v*` tag push (`.github/workflows/release.yml:104`), re-checking out and re-analyzing a commit that was already scanned when it landed on `main`. On a tag ref, `GITHUB_REF_NAME` is the tag itself, so the scanner's CI auto-detection reports the analysis under a branch named after the tag (e.g. `v1.1.0`) instead of `main`. SonarCloud only recognizes the configured main branch (and PRs) for this project, so the quality-gate read-back for that unrecognized branch gets rejected — independent of token validity.

## Fix

Skip the `SonarQube scan` step when `github.ref_type == 'tag'`. The commit was already analyzed (and passed) under the correct branch name during the `main` push CI run that preceded the release; re-analyzing it under the tag ref was both redundant and broken.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm run build`
- Workflow YAML change only — verified by inspection; can't run GitHub Actions locally. Once merged, the next `v*` tag push (or a re-run of the `v1.1.0` release workflow) should show `Checks / SonarQube` as skipped instead of failed, and the release should proceed to `Publish release`.

## Notes

`v1.1.0` is tagged on GitHub but nothing was actually published (npm, GitHub Packages, site deploy) because this gate blocked every downstream job. Once this merges, the `v1.1.0` release workflow run should be re-run (or the tag re-pushed) to complete the actual publish.


---
_Generated by [Claude Code](https://claude.ai/code/session_0153zRuREzddFrTb7GUNffR7)_