### PR TITLE
feat(lint,test): enforce esc() at innerHTML sites, automate XSS coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   `items.map(...).join('')` built from a safe per-item template,
   or the `html` tagged-template helper. CLAUDE.md's hard rule #1 ("use `esc()`
   for every interpolated string") was previously enforced by convention only —
-  this makes it a lint failure instead. Fixed five call sites that
-  interpolated an unescaped value into `innerHTML`
-  (`anchor.ts`, `kaleido.ts`, `radio-group.ts`, `result.ts`, `select.ts`):
-  none were exploitable today (the values come from a hardcoded color list, a
-  validated status enum, or an internally generated id), but wrapping them in
-  `esc()` closes the gap against a future refactor and lets the rule apply
-  uniformly across every `innerHTML` template.
+  this makes it a lint failure instead. The survey behind the rule turned up
+  six interpolations across `anchor.ts`, `kaleido.ts`, `radio-group.ts`,
+  `result.ts` and `select.ts` that weren't wrapped in `esc()`; none are
+  exploitable (a loop index, `numAttr()`-derived arithmetic, a boolean
+  comparison, a closed status-enum union, an internally generated `randId()`
+  id, and a hardcoded color-array lookup — none can carry the characters
+  `esc()` escapes), so each site keeps its bare interpolation with an inline
+  `eslint-disable`/`-enable` and a comment explaining why, rather than paying
+  bundle bytes against the `size-limit` budget for no security benefit.
 - `security.test.ts` now discovers its component list automatically via
   `import.meta.glob`, instead of a hand-maintained `beforeAll` import list: it
   registers every component in `src/components/*.ts`, then statically derives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- An ESLint rule (`local/no-unescaped-innerhtml`, scoped to `src/components/**/*.ts`)
+  that flags an `innerHTML` template-literal assignment whose interpolations
+  aren't escaped via `esc()`/`iconSvg()`, a ternary of safe branches, an
+  `items.map(...).join('')` built from a safe per-item template,
+  or the `html` tagged-template helper. CLAUDE.md's hard rule #1 ("use `esc()`
+  for every interpolated string") was previously enforced by convention only —
+  this makes it a lint failure instead. Fixed five call sites that
+  interpolated an unescaped value into `innerHTML`
+  (`anchor.ts`, `kaleido.ts`, `radio-group.ts`, `result.ts`, `select.ts`):
+  none were exploitable today (the values come from a hardcoded color list, a
+  validated status enum, or an internally generated id), but wrapping them in
+  `esc()` closes the gap against a future refactor and lets the rule apply
+  uniformly across every `innerHTML` template.
+- `security.test.ts` now discovers its component list automatically via
+  `import.meta.glob`, instead of a hand-maintained `beforeAll` import list: it
+  registers every component in `src/components/*.ts`, then statically derives
+  which files interpolate into `innerHTML` and which `@attr {string}` values
+  they document, and runs the existing XSS payload sweep against each one. A
+  new component with an unescaped `innerHTML` interpolation can no longer ship
+  without XSS coverage.
 - A 404 page on the website, built from the same shell as every other page and
   listing all of them as real links. It is written to `dist-site/404.html`,
   stays out of the sitemap, `llms.txt` and the markdown alternates, and carries

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import noUnescapedInnerHtml from './scripts/eslint-rules/no-unescaped-innerhtml.mjs';
 
 // `defineConfig`/`globalIgnores` from eslint/config rather than
 // `tseslint.config()`: typescript-eslint deprecated its own wrapper in favour
@@ -36,6 +37,19 @@ export default defineConfig([
       ],
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       eqeqeq: ['error', 'smart'],
+    },
+  },
+  {
+    // Mechanical enforcement of the esc() contract (CLAUDE.md hard rule #1).
+    // Scoped to components rather than all of src/ — core/dom.ts is where
+    // `esc`/`html` themselves live, and stories/demo don't render untrusted
+    // input.
+    files: ['src/components/**/*.ts'],
+    plugins: {
+      local: { rules: { 'no-unescaped-innerhtml': noUnescapedInnerHtml } },
+    },
+    rules: {
+      'local/no-unescaped-innerhtml': 'error',
     },
   },
 ]);

--- a/scripts/eslint-rules/no-unescaped-innerhtml.mjs
+++ b/scripts/eslint-rules/no-unescaped-innerhtml.mjs
@@ -1,0 +1,121 @@
+// Mechanical enforcement of CLAUDE.md hard rule #1: every value interpolated
+// into an `innerHTML` template literal must go through `esc()`. Skipping it
+// is an XSS vector the moment the interpolated expression stops being
+// compile-time-safe data — which is exactly the kind of change a future
+// refactor can introduce without anyone noticing, since the string still
+// looks fine in review. This rule catches it at lint time instead.
+//
+// Design note: a naive "every ${} must literally be esc(...)" check has real
+// false positives in this codebase — `${iconSvg(...)}` returns trusted,
+// pre-built SVG markup (not user data), ternaries frequently branch between
+// static string literals (`${cond ? 'checked' : ''}`), and several
+// components build a list of markup with `items.map(item => \`...\`).join('')`
+// where the per-item template already escapes its own interpolations. All
+// three shapes are recognized as safe below; anything else is flagged.
+
+const SAFE_CALLEES = new Set(['esc', 'iconSvg']);
+
+function isSafeExpression(node) {
+  if (!node) return true;
+  switch (node.type) {
+    case 'Literal':
+      return typeof node.value === 'string';
+    case 'TemplateLiteral':
+      return node.expressions.every(isSafeExpression);
+    case 'ConditionalExpression':
+      return isSafeExpression(node.consequent) && isSafeExpression(node.alternate);
+    case 'CallExpression':
+      return isSafeCall(node);
+    default:
+      return false;
+  }
+}
+
+function isSafeCall(node) {
+  const { callee } = node;
+  if (callee.type === 'Identifier' && SAFE_CALLEES.has(callee.name)) return true;
+  // `<items>.map(item => `...`).join(sep)` — safe when the per-item
+  // template it builds is itself made of safe expressions.
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'join'
+  ) {
+    return isSafeMapCall(callee.object);
+  }
+  return false;
+}
+
+function isSafeMapCall(node) {
+  if (
+    node.type !== 'CallExpression' ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.computed ||
+    node.callee.property.type !== 'Identifier' ||
+    node.callee.property.name !== 'map'
+  ) {
+    return false;
+  }
+  const callback = node.arguments[node.arguments.length - 1];
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression')
+  ) {
+    return false;
+  }
+  const { body } = callback;
+  if (body.type === 'BlockStatement') {
+    const returns = body.body.filter((statement) => statement.type === 'ReturnStatement');
+    return returns.length > 0 && returns.every((statement) => isSafeExpression(statement.argument));
+  }
+  return isSafeExpression(body);
+}
+
+function isInnerHtmlAssignmentTarget(node) {
+  return (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'innerHTML'
+  );
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require every interpolated expression in an innerHTML template literal to be escaped (esc()/iconSvg(), a ternary or map/join built from safe values), or built through the html tagged template.',
+    },
+    schema: [],
+    messages: {
+      unescaped:
+        'Interpolated value in an innerHTML template literal is not escaped. Wrap it in esc() (see core/dom.ts) — CLAUDE.md hard rule #1 requires esc() for every interpolated string in innerHTML; skipping it is an XSS vector.',
+    },
+  },
+  create(context) {
+    return {
+      AssignmentExpression(node) {
+        if (node.operator !== '=' || !isInnerHtmlAssignmentTarget(node.left)) return;
+        const { right } = node;
+        // Built through the auto-escaping `html` tagged template — every
+        // interpolation is escaped by definition, nothing further to check.
+        if (
+          right.type === 'TaggedTemplateExpression' &&
+          right.tag.type === 'Identifier' &&
+          right.tag.name === 'html'
+        ) {
+          return;
+        }
+        if (right.type !== 'TemplateLiteral') return;
+        for (const expression of right.expressions) {
+          if (!isSafeExpression(expression)) {
+            context.report({ node: expression, messageId: 'unescaped' });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/components/__tests__/security.test.ts
+++ b/src/components/__tests__/security.test.ts
@@ -1,24 +1,34 @@
 // XSS surface tests: ensure that user-supplied attribute values are never
 // rendered as raw HTML inside component templates.
+//
+// Two layers:
+//   1. Hand-written cases below, kept for the components whose escaping
+//      needed an assertion more specific than "no injected node appeared"
+//      (e.g. verifying the escaped text still round-trips through
+//      `textContent`, or that a JSON-encoded label was escaped).
+//   2. An automated sweep at the bottom that discovers every component file
+//      with an `innerHTML = \`...${...}\`` template (via `import.meta.glob`
+//      raw source) and every `@attr {string}` it documents, then mounts each
+//      with an XSS payload in that attribute. New components pick this up
+//      for free — nothing here needs to be hand-maintained per component.
+/// <reference types="vite/client" />
 import { describe, it, expect, beforeAll } from 'vitest';
 
+// Side-effect import every component module so its custom element is
+// registered. Using a glob instead of a fixed list means a newly added
+// component is automatically covered by the sweep below without anyone
+// having to remember to add an import here.
+const componentModules = import.meta.glob<Record<string, unknown>>('../*.ts');
+// Raw source text of the same files, used only to statically derive which
+// components interpolate into `innerHTML` and which attributes they accept.
+const componentSources = import.meta.glob<string>('../*.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
 beforeAll(async () => {
-  await import('../date-picker');
-  await import('../time-picker');
-  await import('../calendar');
-  await import('../cascader');
-  await import('../tree-select');
-  await import('../input');
-  await import('../select');
-  await import('../textarea');
-  await import('../input-number');
-  await import('../checkbox-group');
-  await import('../upload');
-  await import('../alert');
-  await import('../dialog');
-  await import('../popover');
-  await import('../collapse');
-  await import('../tree');
+  await Promise.all(Object.values(componentModules).map((load) => load()));
 });
 
 const mount = (html: string): HTMLElement => {
@@ -34,15 +44,20 @@ const XSS_PAYLOADS = [
   '<svg onload=alert(1)>',
 ];
 
+/** Asserts none of the standard payload markers made it into the rendered subtree. */
+const expectNoInjection = (el: HTMLElement | null): void => {
+  expect(el?.querySelector('img[onerror]') ?? null).toBeNull();
+  expect(el?.querySelector('script') ?? null).toBeNull();
+  expect(el?.querySelector('svg[onload]') ?? null).toBeNull();
+};
+
 describe('XSS prevention', () => {
   for (const payload of XSS_PAYLOADS) {
     it(`e-date-picker value does not inject HTML: ${payload.slice(0, 30)}`, () => {
       const el = mount(
         `<e-date-picker value="${payload.replace(/"/g, '&quot;')}"></e-date-picker>`,
       );
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       el.remove();
     });
 
@@ -50,9 +65,7 @@ describe('XSS prevention', () => {
       const el = mount(
         `<e-date-picker placeholder="${payload.replace(/"/g, '&quot;')}"></e-date-picker>`,
       );
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       el.remove();
     });
   }
@@ -128,25 +141,19 @@ describe('XSS prevention', () => {
   for (const payload of XSS_PAYLOADS) {
     it(`e-alert heading does not inject HTML: ${payload.slice(0, 30)}`, () => {
       const el = mount(`<e-alert heading="${payload.replace(/"/g, '&quot;')}"></e-alert>`);
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-alert__heading')!.textContent).toBe(payload);
     });
 
     it(`e-dialog heading does not inject HTML: ${payload.slice(0, 30)}`, () => {
       const el = mount(`<e-dialog heading="${payload.replace(/"/g, '&quot;')}"></e-dialog>`);
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-dialog__title')!.textContent).toBe(payload);
     });
 
     it(`e-popover heading does not inject HTML: ${payload.slice(0, 30)}`, () => {
       const el = mount(`<e-popover heading="${payload.replace(/"/g, '&quot;')}"></e-popover>`);
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-popover__heading')!.textContent).toBe(payload);
     });
 
@@ -155,9 +162,7 @@ describe('XSS prevention', () => {
       const el = mount(
         `<e-popconfirm message="${escaped}" confirm-label="${escaped}" cancel-label="${escaped}"></e-popconfirm>`,
       );
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-popconfirm__message')!.textContent).toBe(payload);
       expect(el.querySelector('.ink-popconfirm__confirm')!.textContent).toBe(payload);
     });
@@ -166,19 +171,70 @@ describe('XSS prevention', () => {
       const el = mount(
         `<e-collapse><e-collapse-panel key="a" heading="${payload.replace(/"/g, '&quot;')}">b</e-collapse-panel></e-collapse>`,
       );
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-collapse__heading')!.textContent).toBe(payload);
     });
 
     it(`e-tree labels do not inject HTML: ${payload.slice(0, 30)}`, () => {
       const data = JSON.stringify([{ value: 'a', label: payload }]).replace(/"/g, '&quot;');
       const el = mount(`<e-tree data="${data}"></e-tree>`);
-      expect(el.querySelector('img[onerror]')).toBeNull();
-      expect(el.querySelector('script')).toBeNull();
-      expect(el.querySelector('svg[onload]')).toBeNull();
+      expectNoInjection(el);
       expect(el.querySelector('.ink-tree__label')!.textContent).toBe(payload);
     });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Automated sweep: every component that interpolates into `innerHTML` gets
+// every `@attr {string}` it documents fuzzed with each payload above. This
+// doesn't replace the curated cases (which assert exact escaped text lands
+// in a specific node); it's a net under them so a *new* component that adds
+// an `innerHTML` template with a raw `${attr}` doesn't ship untested. The
+// ESLint rule `local/no-unescaped-innerhtml` catches the same class of bug
+// at lint time — this is the runtime backstop.
+// ---------------------------------------------------------------------------
+
+interface SweepTarget {
+  tag: string;
+  attrs: string[];
+}
+
+function discoverSweepTargets(): SweepTarget[] {
+  const targets: SweepTarget[] = [];
+  for (const source of Object.values(componentSources)) {
+    // Matches `something.innerHTML = \`...${` — a template literal
+    // assignment with at least one interpolation. Static templates with no
+    // `${}` (nothing to escape) and non-template assignments (e.g.
+    // `el.innerHTML = iconSvg(...)`) don't match and are skipped.
+    if (!/\.innerHTML\s*=\s*`[^`]*\$\{/.test(source)) continue;
+
+    const tagMatches = [...source.matchAll(/define\(\s*'([\w-]+)'/g)];
+    if (tagMatches.length === 0) continue;
+    // A file's `innerHTML` template belongs to its primary export — the
+    // first `define()` call. Secondary tags in the same file (e.g. the
+    // `<e-option>` in select.ts) are plain data carriers with no template
+    // of their own.
+    const tag = tagMatches[0]![1]!;
+
+    const attrs = [...source.matchAll(/@attr\s+\{string\}\s+\[?([\w-]+)/g)].map((m) => m[1]!);
+    if (attrs.length === 0) continue;
+
+    targets.push({ tag, attrs: [...new Set(attrs)] });
+  }
+  return targets;
+}
+
+describe('XSS prevention — automated attribute sweep', () => {
+  for (const { tag, attrs } of discoverSweepTargets()) {
+    for (const attr of attrs) {
+      for (const payload of XSS_PAYLOADS) {
+        it(`${tag}[${attr}] does not inject HTML: ${payload.slice(0, 30)}`, () => {
+          const escaped = payload.replace(/"/g, '&quot;');
+          const el = mount(`<${tag} ${attr}="${escaped}"></${tag}>`);
+          expectNoInjection(el);
+          el?.remove();
+        });
+      }
+    }
   }
 });

--- a/src/components/__tests__/security.test.ts
+++ b/src/components/__tests__/security.test.ts
@@ -202,24 +202,35 @@ interface SweepTarget {
 function discoverSweepTargets(): SweepTarget[] {
   const targets: SweepTarget[] = [];
   for (const source of Object.values(componentSources)) {
-    // Matches `something.innerHTML = \`...${` — a template literal
-    // assignment with at least one interpolation. Static templates with no
-    // `${}` (nothing to escape) and non-template assignments (e.g.
-    // `el.innerHTML = iconSvg(...)`) don't match and are skipped.
-    if (!/\.innerHTML\s*=\s*`[^`]*\$\{/.test(source)) continue;
+    // A file may define more than one custom element — e.g. popover.ts
+    // defines both `<e-popover>` and `<e-popconfirm>`, each with its own
+    // JSDoc and its own `innerHTML` template. Split the source at each
+    // `define()` call: everything from the end of the previous `define()`
+    // (or the start of the file) up to and including a given `define()`
+    // call belongs to *that* call's component, since a component's JSDoc
+    // and class body always precede its own `define()`. This keeps a later
+    // component's template from being missed (attributed only to the
+    // file's first tag) and keeps an earlier component's attrs from
+    // leaking into a later one.
+    const defineMatches = [...source.matchAll(/define\(\s*'([\w-]+)'\s*,\s*\w+\s*\)/g)];
+    let prevEnd = 0;
+    for (const match of defineMatches) {
+      const end = match.index! + match[0].length;
+      const segment = source.slice(prevEnd, end);
+      prevEnd = end;
 
-    const tagMatches = [...source.matchAll(/define\(\s*'([\w-]+)'/g)];
-    if (tagMatches.length === 0) continue;
-    // A file's `innerHTML` template belongs to its primary export — the
-    // first `define()` call. Secondary tags in the same file (e.g. the
-    // `<e-option>` in select.ts) are plain data carriers with no template
-    // of their own.
-    const tag = tagMatches[0]![1]!;
+      // Matches `something.innerHTML = \`...${` — a template literal
+      // assignment with at least one interpolation. Static templates with
+      // no `${}` (nothing to escape) and non-template assignments (e.g.
+      // `el.innerHTML = iconSvg(...)`) don't match and are skipped.
+      if (!/\.innerHTML\s*=\s*`[^`]*\$\{/.test(segment)) continue;
 
-    const attrs = [...source.matchAll(/@attr\s+\{string\}\s+\[?([\w-]+)/g)].map((m) => m[1]!);
-    if (attrs.length === 0) continue;
+      const tag = match[1]!;
+      const attrs = [...segment.matchAll(/@attr\s+\{string\}\s+\[?([\w-]+)/g)].map((m) => m[1]!);
+      if (attrs.length === 0) continue;
 
-    targets.push({ tag, attrs: [...new Set(attrs)] });
+      targets.push({ tag, attrs: [...new Set(attrs)] });
+    }
   }
   return targets;
 }

--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -47,8 +47,8 @@ export class EAnchor extends HTMLElement {
             .map(
               (it, i) => `
             <li><a class="ink-anchor__link" href="${esc(it.href)}"
-                   data-anchor="${i}"
-                   style="padding-left:${14 + (it.depth || 0) * 14}px">
+                   data-anchor="${esc(i)}"
+                   style="padding-left:${esc(14 + (it.depth || 0) * 14)}px">
               <span class="ink-anchor__marker" aria-hidden="true">  </span>${esc(it.title)}
             </a></li>`,
             )

--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -39,6 +39,11 @@ export class EAnchor extends HTMLElement {
         title: it.getAttribute('title') || '',
         depth: numAttr(it, 'depth', 0),
       }));
+      // `i` and the `depth`-derived offset below are both numbers (a loop
+      // index and numAttr()-sourced arithmetic) — they can never carry the
+      // characters esc() escapes, so wrapping them would only cost bundle
+      // bytes against the size-limit budget for no security benefit.
+      /* eslint-disable local/no-unescaped-innerhtml */
       this.innerHTML = `
       <nav class="ink-anchor" aria-label="In-page navigation">
         <div class="ink-anchor__title">ON THIS PAGE</div>
@@ -47,14 +52,15 @@ export class EAnchor extends HTMLElement {
             .map(
               (it, i) => `
             <li><a class="ink-anchor__link" href="${esc(it.href)}"
-                   data-anchor="${esc(i)}"
-                   style="padding-left:${esc(14 + (it.depth || 0) * 14)}px">
+                   data-anchor="${i}"
+                   style="padding-left:${14 + (it.depth || 0) * 14}px">
               <span class="ink-anchor__marker" aria-hidden="true">  </span>${esc(it.title)}
             </a></li>`,
             )
             .join('')}
         </ul>
       </nav>`;
+      /* eslint-enable local/no-unescaped-innerhtml */
       this._scrollHandler = this._updateActive;
     }
     this._updateActive();

--- a/src/components/kaleido.ts
+++ b/src/components/kaleido.ts
@@ -84,6 +84,11 @@ export class EKaleido extends HTMLElement {
 
   private _render(): void {
     const cell = numAttr(this, 'cell', 3);
+    // `c.hex`/`c.name` come from KALEIDO_COLORS, a hardcoded module-level
+    // const array — never user-controlled — so they can't carry the
+    // characters esc() escapes, and wrapping them would only cost bundle
+    // bytes against the size-limit budget.
+    /* eslint-disable local/no-unescaped-innerhtml */
     this.innerHTML = `<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));
                                   gap:0;border:var(--ink-border);border-right:none;border-bottom:none">
       ${KALEIDO_COLORS.map(
@@ -91,12 +96,12 @@ export class EKaleido extends HTMLElement {
         <div style="border-right:var(--ink-border);border-bottom:var(--ink-border);
                     background:var(--ink-bg);font-family:var(--ink-sans);color:var(--ink-fg)">
           <div style="display:grid;grid-template-columns:1fr 1fr;border-bottom:var(--ink-border)">
-            <div style="background:${esc(c.hex)};height:88px;border-right:var(--ink-border);
+            <div style="background:${c.hex};height:88px;border-right:var(--ink-border);
                         display:flex;align-items:flex-end;padding:6px 8px;
                         color:${DARK_TEXT_LABELS.has(c.name) ? '#000' : '#FFF'};
                         font-size:10px;font-weight:700;letter-spacing:0.18em">IDEAL</div>
             <div style="position:relative">
-              <canvas data-color="${esc(c.hex)}" style="display:block;image-rendering:pixelated"></canvas>
+              <canvas data-color="${c.hex}" style="display:block;image-rendering:pixelated"></canvas>
               <span style="position:absolute;left:8px;bottom:6px;
                 font-size:10px;font-weight:700;letter-spacing:0.18em;
                 background:#FFF;color:#000;padding:1px 4px;border:1px solid #000">KALEIDO</span>
@@ -104,11 +109,12 @@ export class EKaleido extends HTMLElement {
           </div>
           <div style="padding:10px 12px;display:flex;align-items:baseline;justify-content:space-between">
             <span style="font-size:15px;font-weight:700">${esc(c.name)}</span>
-            <span style="font-size:11px;font-family:var(--ink-mono);letter-spacing:0.04em">${esc(c.hex)}</span>
+            <span style="font-size:11px;font-family:var(--ink-mono);letter-spacing:0.04em">${c.hex}</span>
           </div>
         </div>`,
       ).join('')}
     </div>`;
+    /* eslint-enable local/no-unescaped-innerhtml */
     this.querySelectorAll('canvas').forEach((cv) => {
       paintDither(
         cv as HTMLCanvasElement,

--- a/src/components/kaleido.ts
+++ b/src/components/kaleido.ts
@@ -91,12 +91,12 @@ export class EKaleido extends HTMLElement {
         <div style="border-right:var(--ink-border);border-bottom:var(--ink-border);
                     background:var(--ink-bg);font-family:var(--ink-sans);color:var(--ink-fg)">
           <div style="display:grid;grid-template-columns:1fr 1fr;border-bottom:var(--ink-border)">
-            <div style="background:${c.hex};height:88px;border-right:var(--ink-border);
+            <div style="background:${esc(c.hex)};height:88px;border-right:var(--ink-border);
                         display:flex;align-items:flex-end;padding:6px 8px;
                         color:${DARK_TEXT_LABELS.has(c.name) ? '#000' : '#FFF'};
                         font-size:10px;font-weight:700;letter-spacing:0.18em">IDEAL</div>
             <div style="position:relative">
-              <canvas data-color="${c.hex}" style="display:block;image-rendering:pixelated"></canvas>
+              <canvas data-color="${esc(c.hex)}" style="display:block;image-rendering:pixelated"></canvas>
               <span style="position:absolute;left:8px;bottom:6px;
                 font-size:10px;font-weight:700;letter-spacing:0.18em;
                 background:#FFF;color:#000;padding:1px 4px;border:1px solid #000">KALEIDO</span>
@@ -104,7 +104,7 @@ export class EKaleido extends HTMLElement {
           </div>
           <div style="padding:10px 12px;display:flex;align-items:baseline;justify-content:space-between">
             <span style="font-size:15px;font-weight:700">${esc(c.name)}</span>
-            <span style="font-size:11px;font-family:var(--ink-mono);letter-spacing:0.04em">${c.hex}</span>
+            <span style="font-size:11px;font-family:var(--ink-mono);letter-spacing:0.04em">${esc(c.hex)}</span>
           </div>
         </div>`,
       ).join('')}

--- a/src/components/radio-group.ts
+++ b/src/components/radio-group.ts
@@ -42,7 +42,7 @@ export class ERadioGroup extends BaseFormControl {
         .map(
           (r) => `
         <label class="ink-radio">
-          <input type="radio" name="${name}" value="${esc(r.value)}" ${r.value === value ? 'checked' : ''}/>
+          <input type="radio" name="${esc(name)}" value="${esc(r.value)}" ${r.value === value ? 'checked' : ''}/>
           <span class="ink-radio__dot"></span>
           ${esc(r.label)}
         </label>`,

--- a/src/components/radio-group.ts
+++ b/src/components/radio-group.ts
@@ -37,18 +37,24 @@ export class ERadioGroup extends BaseFormControl {
       value: r.getAttribute('value') ?? '',
       label: r.getAttribute('label') || r.textContent || '',
     }));
+    // `name` is randId('e-rg') — an internally generated id, never a
+    // free-form string — so it can't carry the characters esc() escapes,
+    // and wrapping it would only cost bundle bytes against the size-limit
+    // budget.
+    /* eslint-disable local/no-unescaped-innerhtml */
     this.innerHTML = `<div class="ink-radio-group${layout === 'vertical' ? ' ink-radio-group--vertical' : ''}" role="radiogroup">
       ${radios
         .map(
           (r) => `
         <label class="ink-radio">
-          <input type="radio" name="${esc(name)}" value="${esc(r.value)}" ${r.value === value ? 'checked' : ''}/>
+          <input type="radio" name="${name}" value="${esc(r.value)}" ${r.value === value ? 'checked' : ''}/>
           <span class="ink-radio__dot"></span>
           ${esc(r.label)}
         </label>`,
         )
         .join('')}
     </div>`;
+    /* eslint-enable local/no-unescaped-innerhtml */
     this._value = value;
     this.internals.setFormValue(value);
     this._syncValidity();

--- a/src/components/result.ts
+++ b/src/components/result.ts
@@ -50,7 +50,7 @@ export class EResult extends HTMLElement {
     const status = this._status();
     const title = this.getAttribute('title') || '';
     const desc = this.getAttribute('description') || '';
-    this.innerHTML = `<section class="ink-result" data-status="${status}" role="status">
+    this.innerHTML = `<section class="ink-result" data-status="${esc(status)}" role="status">
       <div class="ink-result__icon" aria-hidden="true">${iconSvg(STATUS_ICON[status], 64)}</div>
       <h2 class="ink-result__title">${esc(title)}</h2>
       ${desc ? `<p class="ink-result__desc">${esc(desc)}</p>` : ''}

--- a/src/components/result.ts
+++ b/src/components/result.ts
@@ -50,7 +50,12 @@ export class EResult extends HTMLElement {
     const status = this._status();
     const title = this.getAttribute('title') || '';
     const desc = this.getAttribute('description') || '';
-    this.innerHTML = `<section class="ink-result" data-status="${esc(status)}" role="status">
+    // `status` is narrowed to the closed `Status` union by `_status()`'s
+    // `isStatus()` guard — never a free-form string — so it can't carry the
+    // characters esc() escapes, and wrapping it would only cost bundle
+    // bytes against the size-limit budget.
+    // eslint-disable-next-line local/no-unescaped-innerhtml
+    this.innerHTML = `<section class="ink-result" data-status="${status}" role="status">
       <div class="ink-result__icon" aria-hidden="true">${iconSvg(STATUS_ICON[status], 64)}</div>
       <h2 class="ink-result__title">${esc(title)}</h2>
       ${desc ? `<p class="ink-result__desc">${esc(desc)}</p>` : ''}

--- a/src/components/select.ts
+++ b/src/components/select.ts
@@ -55,7 +55,7 @@ export class ESelect extends BaseFormControl {
         ${this._opts
           .map(
             (o) => `<li class="ink-select__option" role="option"
-          data-value="${esc(o.value)}" aria-selected="${o.value === value}">
+          data-value="${esc(o.value)}" aria-selected="${esc(o.value === value)}">
           <span style="flex:1">${esc(o.label)}</span>
           ${o.value === value ? iconSvg('check', 16) : ''}
         </li>`,

--- a/src/components/select.ts
+++ b/src/components/select.ts
@@ -51,6 +51,10 @@ export class ESelect extends BaseFormControl {
         label: o.getAttribute('label') || o.textContent || '',
       }));
       const current = this._opts.find((o) => o.value === value);
+      // `o.value === value` is a boolean (stringifies to "true"/"false") —
+      // it can never carry the characters esc() escapes, so wrapping it
+      // would only cost bundle bytes against the size-limit budget.
+      /* eslint-disable local/no-unescaped-innerhtml */
       this.innerHTML = `<div class="ink-select">
       <button type="button" class="ink-select__trigger" aria-haspopup="listbox" aria-expanded="false" aria-controls="${esc(menuId)}">
         <span data-current>${esc(current ? current.label : this._placeholder)}</span>
@@ -60,7 +64,7 @@ export class ESelect extends BaseFormControl {
         ${this._opts
           .map(
             (o) => `<li class="ink-select__option" role="option"
-          data-value="${esc(o.value)}" aria-selected="${esc(o.value === value)}">
+          data-value="${esc(o.value)}" aria-selected="${o.value === value}">
           <span style="flex:1">${esc(o.label)}</span>
           ${o.value === value ? iconSvg('check', 16) : ''}
         </li>`,
@@ -68,6 +72,7 @@ export class ESelect extends BaseFormControl {
           .join('')}
       </ul>
     </div>`;
+      /* eslint-enable local/no-unescaped-innerhtml */
 
       this._trigger = this.querySelector('.ink-select__trigger');
       this._menu = this.querySelector('.ink-select__menu');


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed — n/a, no component API changes; `CHANGELOG.md` updated
- [x] CSS output builds locally (`npm run build`)

PR 4 of 4 from a code review pass (1–3: #52, #53, #54). This one turns CLAUDE.md hard rule #1 ("use `esc()` for every interpolated string [in innerHTML]") from a convention into something mechanically enforced.

**Before:** the auto-escaping `html` tagged-template helper in `core/dom.ts` was imported by zero of the 70 components — every `innerHTML = ` template manually called `esc()` per value instead, by convention only. `security.test.ts`'s XSS coverage was a hand-maintained `beforeAll` import list covering ~16 components. Nothing stopped a new component from shipping an unescaped `${value}` inside an `innerHTML` template.

### Task 1 — ESLint rule

Added `local/no-unescaped-innerhtml` (`scripts/eslint-rules/no-unescaped-innerhtml.mjs`), registered in `eslint.config.mjs` scoped to `src/components/**/*.ts`. It flags an `innerHTML` template-literal assignment whose interpolations aren't:

- an `esc(...)` or `iconSvg(...)` call,
- a ternary whose branches are (recursively) safe,
- `items.map(item => \`...\`).join('')` where the per-item template is itself safe, or
- built through the `html` tagged-template helper.

I surveyed all 56 `innerHTML` call sites across `src/components/*.ts` before writing the rule — a naive "every `${}` must literally be `esc(...)`" check has real false positives here: `${iconSvg(...)}` returns pre-built trusted SVG (not user data), and ternaries very commonly branch between static string literals (`${cond ? 'checked' : ''}`). Both shapes are recognized as safe rather than rejected.

That survey also turned up six genuine gaps across `anchor.ts`, `kaleido.ts`, `radio-group.ts`, `result.ts`, `select.ts` — each interpolating a value without `esc()`. None are exploitable (a loop index, `numAttr()`-derived arithmetic, a boolean comparison, a closed status-enum union, an internally generated `randId()` id, and a hardcoded color-array lookup — none can ever carry the characters `esc()` escapes). I first wrapped all of them in `esc()` for lint-rule uniformity, but that pushed the barrel bundle 11 B over the `size-limit` budget (see Testing below) for zero real security benefit, so each site now keeps its bare interpolation with an inline `eslint-disable`/`-enable` pair and a comment explaining why it's safe — comments are stripped by the minifier, so this costs nothing in `dist/`, and the disable is scoped to just that statement so a future edit that actually introduces user data there still trips the rule.

### Task 2 — automated XSS coverage

Rewrote `security.test.ts`'s `beforeAll` to register every component via `import.meta.glob('../*.ts')` instead of a fixed list, and added an automated sweep: it statically finds every component with an `innerHTML = \`...${...}...\`` template and every `@attr {string}` it documents, then mounts each with the existing `XSS_PAYLOADS` in that attribute and asserts nothing injected. New components get coverage automatically.

A Copilot review on this PR caught a real bug here: the sweep originally attributed a whole file's template/attrs to only its *first* `define()` call, so `popover.ts`'s second component (`<e-popconfirm>`, which has its own `innerHTML` template) got zero automated coverage. Fixed by splitting each file's source at its `define()` call boundaries instead — a component's JSDoc/class body always precede its own `define()`, so that's now the attribution point. Verified `e-popconfirm[message/confirm-label/cancel-label]` are generated and passing.

The existing hand-written cases (which assert exact escaped text lands in a specific node, e.g. `e-alert`'s heading) are kept as-is; the sweep is a net under them, not a replacement.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check` — confirmed the rule fires by temporarily reverting a suppression/`esc()` call and re-linting; restored before each commit
- [x] `npm run build` + `npm run size` — CI caught a real regression here: `main` was already at 39.95 kB (50 B under the 40 KB barrel budget), and my initial `esc()`-everywhere approach added just enough bytes to fail at 40.01 kB. Fixed by reverting to inline lint suppressions (see Task 1); confirmed back to the 39.95 kB baseline post-fix.
- [x] `security.test.ts` (232 tests, up from ~55) + `reactivity.test.ts` + `cleanup.test.ts` + `form-association.test.ts` + `data-display.test.ts` + `new-components.test.ts` — all green (455 tests total)
- [x] Confirmed the automated sweep isn't vacuous: temporarily removed `esc()` from `checkbox.ts`'s label render, reran — sweep failed with the expected `<svg onload>` injection, then reverted
- [x] Confirmed each `eslint-disable` suppression is live, not decorative: temporarily removed one and re-linted — failed as expected, restored
- [x] `screenshots.test.ts` has 22 pre-existing failures on a clean `main` checkout in this sandbox (confirmed via `git stash`) — unrelated to this change, looks like a baseline/font-rendering mismatch for this container's Playwright/Chromium build, not something this PR introduced or fixes
- [x] Merged `main` in after PR #54 landed underneath this branch (both added a `CHANGELOG.md [Unreleased]` entry at the same spot) — resolved by keeping both, `radio-group.ts`/`select.ts` auto-merged cleanly alongside the new type-ahead feature

## Notes

- No component public API changed.
- The custom rule lives under `scripts/eslint-rules/` (excluded from ESLint's own `globalIgnores` and covered by `format:check`'s `scripts/**/*.mjs` glob) rather than as a `no-restricted-syntax` selector — the safe-pattern recognition (ternaries, `map().join()`, nested templates) needs real recursive AST logic that a selector-based rule can't express cleanly.
- Didn't touch PRs #52/#53/#54 or scope-creep into `<e-select>`'s `filter` attribute per the review pass notes.
