### PR TITLE
Fix e-input-number ignoring empty min/max attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `<e-input-number>`: an empty `min` or `max` attribute (e.g. `min=""`, as
+  rendered by templating that always emits the attribute) was coerced by
+  `Number('')` to `0` and treated as a real bound, silently clamping the
+  value to `0` and blocking the increment/decrement buttons. Empty strings
+  are now treated the same as an absent attribute (unbounded).
 - `BaseFormControl`: `form.reset()` now clears the surfaced-validation flag
   before re-deriving validity from the restored value, so a control the user
   had already blurred (and which showed `aria-invalid`) returns to its

--- a/src/components/__tests__/form-association.test.ts
+++ b/src/components/__tests__/form-association.test.ts
@@ -560,6 +560,28 @@ describe('form association', () => {
     expect(control.checkValidity()).toBe(true);
   });
 
+  it('e-input-number treats empty min/max attributes as unbounded, not zero', () => {
+    // Regression: Storybook (and any templating that always renders min/max
+    // attributes) sets min="" and max="" when no bound is configured.
+    // Number('') is 0, which used to be mistaken for a real bound of 0.
+    const form = mount(
+      '<form><e-input-number name="v" value="5" min="" max="" step="1"></e-input-number></form>',
+    );
+    const control = form.firstElementChild as HTMLElement;
+    const input = control.querySelector('input')!;
+    expect(input.hasAttribute('min')).toBe(false);
+    expect(input.hasAttribute('max')).toBe(false);
+
+    const inc = control.querySelector<HTMLButtonElement>('[data-step="1"]')!;
+    inc.click();
+    expect(input.value).toBe('6');
+
+    const dec = control.querySelector<HTMLButtonElement>('[data-step="-1"]')!;
+    dec.click();
+    dec.click();
+    expect(input.value).toBe('4');
+  });
+
   it('e-input-number updates host validity while the user edits', () => {
     const form = mount(
       '<form><e-input-number name="v" value="1" required></e-input-number></form>',

--- a/src/components/input-number.ts
+++ b/src/components/input-number.ts
@@ -170,7 +170,7 @@ export class EInputNumber extends BaseFormControl<string> {
 
   private _setFiniteInputAttr(name: 'min' | 'max', value: string | null): void {
     if (!this._input) return;
-    const parsed = value == null ? NaN : Number(value);
+    const parsed = value == null || value === '' ? NaN : Number(value);
     if (Number.isFinite(parsed)) this._input.setAttribute(name, String(parsed));
     else this._input.removeAttribute(name);
   }


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed (CHANGELOG entry added; no story change needed — the bug was in the component, not the story)
- [x] CSS output builds locally (`npm run build`)

Reported via the Storybook `Inputs/InputNumber` → `Default` story: starting at `5`, clicking `+` did nothing and clicking `-` jumped straight to `0`.

Root cause: `<e-input-number>`'s `_setFiniteInputAttr` coerced `min`/`max` attribute values with `Number(value)`. When the attribute was present but empty (`min=""`, `max=""` — exactly what the `Default` story's template renders via `min=${args.min ?? ''}` since no bound is configured), `Number('')` evaluates to `0`, which `Number.isFinite` accepts as a real bound. The native `<input>` silently ended up with `min="0" max="0"`, so with a starting value of `5` the increment button became a no-op (already above `max`) and the decrement button clamped straight down to the (bogus) `min` of `0`.

Fix: treat an empty string the same as an absent attribute (unbounded), matching how the rest of the component already treats `null`.

Also added a regression test (`e-input-number treats empty min/max attributes as unbounded, not zero` in `form-association.test.ts`) that mounts the component with literal `min=""`/`max=""` attributes and exercises both buttons — verified it fails without the fix and passes with it. Investigated other input components (`input.ts`, `upload.ts`, `change-marker.ts`, `statistic.ts`, etc.) for the same `Number('') === 0` coercion pattern; none of them have it, so this appears isolated to `input-number.ts`.

## Testing

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run --project unit src/components/__tests__/form-association.test.ts` (58/58 passing, including the new regression test; confirmed it fails on the pre-fix code)

## Notes

The full `--project unit` suite has 22 pre-existing screenshot-comparison failures unrelated to this change (font/rendering baseline mismatches in this sandbox environment) — reproduced identically on `main` before my changes, so not introduced by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KVKmHgpy27ApsqkS34sn88)_