### PR TITLE
Bump Playwright to 1.62.1 across package, dev container, and CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "EPaper Components — Playwright CI",
-  "image": "mcr.microsoft.com/playwright:v1.59.1-noble",
+  "image": "mcr.microsoft.com/playwright:v1.62.1-noble",
   "containerUser": "pwuser",
   "remoteUser": "pwuser",
   "updateRemoteUserUID": false,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
       options: --user 1001
     steps:
       - name: Checkout
@@ -65,7 +65,7 @@ jobs:
     container:
       # Keep browser rendering identical to the environment used to create the
       # visual-regression baselines. This tag must match package-lock.json.
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
       options: --user 1001
     steps:
       - name: Checkout
@@ -110,7 +110,7 @@ jobs:
       # Keep the browser, its system dependencies, and visual-regression
       # rendering identical to the environment used to create CI baselines.
       # This tag must match the Playwright version in package-lock.json.
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
       options: --user 1001
     steps:
       - name: Checkout

--- a/.github/workflows/visual-baselines.yml
+++ b/.github/workflows/visual-baselines.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Must stay identical to ci.yml — that is the entire point of this job.
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
       options: --user 1001
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Playwright bumped from 1.59.1 to 1.62.1 (`package.json`, `package-lock.json`),
+  with the dev container and every CI job that pins the matching
+  `mcr.microsoft.com/playwright` image (`ci.yml`, `visual-baselines.yml`)
+  updated to `v1.62.1-noble` alongside it so the browser build stays
+  identical everywhere visual-regression baselines are created or compared.
 - `CLAUDE.md` renamed to `AGENTS.md`, following the cross-tool
   [AGENTS.md](https://agents.md) convention so other coding agents pick it
   up by default. A one-line `CLAUDE.md` stub (`@AGENTS.md` import) remains

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "10.8.1",
         "lightningcss": "1.33.0",
         "lit": "3.3.3",
-        "playwright": "1.59.1",
+        "playwright": "1.62.1",
         "prettier": "3.9.6",
         "size-limit": "13.0.3",
         "storybook": "10.5.9",
@@ -9669,35 +9669,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -473,7 +473,7 @@
     "eslint": "10.8.1",
     "lightningcss": "1.33.0",
     "lit": "3.3.3",
-    "playwright": "1.59.1",
+    "playwright": "1.62.1",
     "prettier": "3.9.6",
     "size-limit": "13.0.3",
     "storybook": "10.5.9",


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [ ] Demo/story/docs updated if needed — n/a, no component/story changes
- [x] CSS output builds locally (`npm run build`)

Bumps `playwright` from `1.59.1` to the current latest stable, `1.62.1`
(`package.json`, `package-lock.json`), and repoints every pinned
`mcr.microsoft.com/playwright` image reference to the matching
`v1.62.1-noble` tag so the browser build stays identical everywhere:

- `.devcontainer/devcontainer.json`
- `.github/workflows/ci.yml` (quality, tests, build jobs)
- `.github/workflows/visual-baselines.yml`

`CHANGELOG.md` documents the bump under `[Unreleased] → Changed`.

## Testing

- [x] `npm run format:check`
- [x] `npm run typecheck` (ran as `npm run type-check`)
- [x] `npm run build`
- [x] `npm run lint:check`

Browser-backed tests (`npm run test:coverage:ci`, `test:visual`) need the
pinned Playwright container and can't be exercised in this sandbox — the
`Update visual baselines` workflow will be run against this branch to
regenerate `__screenshots__/` under the new `v1.62.1-noble` image and
confirm the suite is green.

## Notes

Only the Playwright package/image versions changed — no rendering-affecting
code changed, so most baselines are expected to come out byte-identical,
but any that shift due to the newer Chromium build will be refreshed by the
baseline-regeneration workflow rather than by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_012D2mh3kWVQ4bySBQf2LsSH)_