### PR TITLE
ci: skip BrowserStack and dev npm publish for website-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,69 @@ jobs:
           args: >
             -Dsonar.qualitygate.wait=true
 
+  # No `needs`, so this runs in parallel with quality/tests/build/sonar
+  # instead of adding latency in front of them. Left unconditional at the job
+  # level (only its steps are conditional) so it always reports `success` —
+  # a skipped *job* would cascade into skipping browserstack/preview/deploy
+  # below too, which is not what a website-only change should do to preview
+  # and deploy.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      website_only: ${{ steps.filter.outputs.website_only }}
+    steps:
+      - name: Checkout
+        if: github.event_name != 'workflow_call'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # The marketing site (src/site/, its Vite config and its build scripts)
+      # ships to epaper-components.dev, never to npm, and none of it is
+      # exercised by the BrowserStack component matrix — so a push or pull
+      # request touching only those paths can skip both safely. Skipped
+      # entirely for the tag-release path (workflow_call from release.yml):
+      # a release always gets the full gate, whatever the tag touches.
+      - name: Determine changed paths
+        id: filter
+        if: github.event_name != 'workflow_call'
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.event.after }}"
+          fi
+
+          # A force-push or a newly created branch has no prior commit to
+          # diff against (`before` is the all-zero SHA) — fall back to
+          # running every gate rather than guessing what changed.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "website_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "$CHANGED"
+
+          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -vE '^(src/site/|vite\.site\.config\.ts$|scripts/(build-site-routes|inline-site-css|site-template|site-shots|github-stars)\.mjs$)' | grep -q .; then
+            echo "website_only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "website_only=true" >> "$GITHUB_OUTPUT"
+          fi
+
   browserstack:
     name: BrowserStack
-    needs: sonar
+    needs: [sonar, changes]
+    # Website-only changes (see the `changes` job above) never touch
+    # component code, so there is nothing for the BrowserStack matrix to catch.
+    if: needs.changes.outputs.website_only != 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/browserstack.yml
@@ -237,7 +297,14 @@ jobs:
   preview:
     name: PR preview
     needs: browserstack
+    # `always()` plus the explicit result check: a website-only skip of
+    # `browserstack` above is a *skip*, not a failure, and must not cascade
+    # into skipping the preview deploy — only a real browserstack failure
+    # should block it.
     if: >-
+      always() &&
+      needs.browserstack.result != 'failure' &&
+      needs.browserstack.result != 'cancelled' &&
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -250,7 +317,13 @@ jobs:
   deploy:
     name: Deploy site and Storybook
     needs: browserstack
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Same reasoning as `preview` above: don't let a website-only browserstack
+    # skip block the site deploy that website change was meant to publish.
+    if: >-
+      always() &&
+      needs.browserstack.result != 'failure' &&
+      needs.browserstack.result != 'cancelled' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,15 +297,67 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ------------------------------------------------------------ dev channel
+
+  # Mirrors the `changes` job in ci.yml: a website-only push must not start
+  # an automatic dev-channel npm publish either. Computed independently here
+  # because a workflow_run event doesn't carry ci.yml's job outputs. Left
+  # unconditional at the job level (only its steps are conditional) so it
+  # always reports `success` and never cascades a skip into `dev` below.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      website_only: ${{ steps.filter.outputs.website_only }}
+    steps:
+      - name: Checkout
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'push'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      # Every push to main that reaches here went through GitHub's merge
+      # button, so it is a single merge commit whose first parent is the
+      # previous tip of main. Diffing tree-to-tree against that parent
+      # reproduces the same before/after comparison ci.yml made for this
+      # push, regardless of how many commits the merged branch contained.
+      - name: Determine changed paths
+        id: filter
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'push'
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse -q --verify HEAD~1 >/dev/null; then
+            echo "website_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED="$(git diff --name-only HEAD~1 HEAD)"
+          echo "$CHANGED"
+
+          if [ -z "$CHANGED" ] || echo "$CHANGED" | grep -vE '^(src/site/|vite\.site\.config\.ts$|scripts/(build-site-routes|inline-site-css|site-template|site-shots|github-stars)\.mjs$)' | grep -q .; then
+            echo "website_only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "website_only=true" >> "$GITHUB_OUTPUT"
+          fi
+
   dev:
     name: Publish dev
+    needs: changes
     if: >-
       github.event_name != 'push' &&
       github.repository == 'marcomattes/epaper-components' &&
       (github.event_name == 'workflow_dispatch' ||
         (github.event.workflow_run.conclusion == 'success' &&
          github.event.workflow_run.event == 'push' &&
-         github.event.workflow_run.head_repository.full_name == github.repository))
+         github.event.workflow_run.head_repository.full_name == github.repository &&
+         needs.changes.outputs.website_only != 'true'))
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,11 @@ CI runs all of the above on every PR (`.github/workflows/ci.yml`).
 `.github/workflows/release.yml` owns both npm channels:
 
 - **`dev`** — every green CI run on `main` publishes
-  `<next-patch>-dev.<run number>` under the `dev` dist-tag. Nothing to do
-  by hand; `package.json` `version` is stamped in CI only, never committed.
+  `<next-patch>-dev.<run number>` under the `dev` dist-tag, _unless_ the
+  push only touched the marketing site (`src/site/`, `vite.site.config.ts`,
+  its build scripts — see the `changes` job in `release.yml`), which isn't
+  part of the npm package and skips the publish. Nothing to do by hand;
+  `package.json` `version` is stamped in CI only, never committed.
 - **`latest`** — pushing a `v*` tag runs four gated stages: `guard`
   (tag equals `v<package.json version>`, fails in seconds otherwise),
   `checks` (calls `ci.yml` as a reusable workflow — do not duplicate the

--- a/BROWSERSTACK.md
+++ b/BROWSERSTACK.md
@@ -69,10 +69,12 @@ Create these repository Actions secrets:
 
 `.github/workflows/ci.yml` calls `.github/workflows/browserstack.yml` after the
 local quality, test, and build stages for every pull request and every push to
-`main`. Fork pull requests do not receive repository secrets, so the workflow
-reports a notice and skips the remote matrix for those runs. It never uses
-`pull_request_target` and therefore never exposes BrowserStack credentials to
-untrusted fork code.
+`main` — except when the change only touches the marketing site (`src/site/`,
+`vite.site.config.ts`, its build scripts; see the `changes` job in `ci.yml`),
+which the component matrix can't exercise anyway and so is skipped. Fork pull
+requests do not receive repository secrets, so the workflow reports a notice
+and skips the remote matrix for those runs. It never uses `pull_request_target`
+and therefore never exposes BrowserStack credentials to untrusted fork code.
 
 Each matrix job builds a static Storybook, starts an isolated BrowserStack Local
 tunnel, runs all stories in one remote session, and retries that complete remote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- CI no longer runs the BrowserStack cross-browser matrix or triggers an
+  automatic `dev`-channel npm publish for pushes and pull requests that only
+  touch the marketing site (`src/site/`, `vite.site.config.ts`, its build
+  scripts) — that code never ships in the npm package and isn't exercised by
+  the component test matrix, so it only needed the local quality/test/build
+  gate and its own FTP deploy, both of which still run unchanged.
 - `CLAUDE.md` renamed to `AGENTS.md`, following the cross-tool
   [AGENTS.md](https://agents.md) convention so other coding agents pick it
   up by default. A one-line `CLAUDE.md` stub (`@AGENTS.md` import) remains


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed
- [x] CSS output builds locally (`npm run build`)

Reduces CI load: a push or pull request that only touches the marketing
site (`src/site/`, `vite.site.config.ts`, and its build scripts under
`scripts/`) no longer triggers the BrowserStack cross-browser matrix in
`ci.yml`, and a website-only push to `main` no longer starts the automatic
`dev`-channel npm publish in `release.yml`. Neither is exercised by or
relevant to site-only code — the site never ships in the npm package, and
BrowserStack only tests component stories.

- Added a `changes` job to `ci.yml` that diffs the push/PR against its
  previous commit and exposes a `website_only` output. `browserstack` is
  skipped when it's `true`; the tag-release path (`workflow_call` from
  `release.yml`) always runs the full gate regardless.
- `preview`/`deploy` (which `need: browserstack`) got an explicit
  `always()` guard so a website-only *skip* of `browserstack` doesn't
  cascade into skipping the site's own preview/FTP deploy — those still
  need to run for a website change.
- Added an equivalent `changes` job to `release.yml`, computed independently
  (a `workflow_run` event doesn't carry `ci.yml`'s job outputs) by diffing
  the pushed merge commit against its first parent. The automatic `dev`
  job now also requires `website_only != 'true'`; manual `workflow_dispatch`
  publishes are unaffected.
- Updated `AGENTS.md`, `BROWSERSTACK.md`, and `CHANGELOG.md` to describe
  the new behavior.

Quality/tests/build/sonar and the site's own FTP deploy are unchanged and
still run for every push/PR.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run build`

## Notes

Workflow YAML was validated with `python3 -c "import yaml; yaml.safe_load(...)"` for both edited files (no `actionlint` binary available in this environment). The path-filter list is: `src/site/**`, `vite.site.config.ts`, `scripts/build-site-routes.mjs`, `scripts/inline-site-css.mjs`, `scripts/site-template.mjs`, `scripts/site-shots.mjs`, `scripts/github-stars.mjs` — everything the site build actually touches, confirmed by grepping for each script's usages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LidF6cn34Nnmpjis1uDvFZ)_