### PR TITLE
feat(site): make the cover page carry the site's subject in prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The website's cover page (`/`) now carries the site's subject in prose
+  instead of only in a masthead. It was roughly sixty words — a headline, a
+  lede and three statistics — which left the FAQ as the only page that spelled
+  "e-ink" next to "web components" in body text, and search results reflected
+  that. The cover keeps the same first screen and continues below the fold
+  with what EPaper is, the four constraints that make a component e-ink-ready,
+  the install snippets, the component categories, the guides and four question
+  teasers, each block linking to the page that covers it in full rather than
+  restating it. Title, `<h1>` and description now name e-ink as well as
+  e-paper.
+- The cover's structured data gained a `SoftwareApplication` node (what to
+  install, and that it is free) and an `ItemList` of the site's sections,
+  alongside the `SoftwareSourceCode` node every page already carried.
+- `/index.md` and `llms.txt` mirror the expanded cover copy, so the markdown
+  alternate an answer engine reads is no longer thinner than the HTML page.
+
 ## [1.2.0] — 2026-08-25
 
 ### Added

--- a/apps/site/src/content.ts
+++ b/apps/site/src/content.ts
@@ -23,7 +23,9 @@ import {
   CALENDAR_EVENTS,
   COMPONENTS,
   CATEGORIES,
+  EINK_CONSTRAINTS,
   FEATURES,
+  HOME_INTRO,
   IMPORT_SNIPPET,
   INSTALL_SNIPPETS,
   ROADMAP,
@@ -37,7 +39,7 @@ import { isNotFound, PACKAGE_NAME, REPO_URL, ROUTES, withBase, type Route } from
 import { shotAlt, shotKey, shotUrl, type ShotIndex } from './shots';
 import { ARTICLES, articlePath, articlesOfKind, readingMinutes, type Article } from './articles';
 import { blocksHtml, inlineHtml, tableOfContents } from './blocks';
-import { FAQ } from './faq';
+import { FAQ, faqId, homeQuestions } from './faq';
 
 export interface ContentOptions {
   /** Deployed Storybook base URL — resolved by the build, not by data.ts. */
@@ -80,11 +82,11 @@ function coverMain(opts: ContentOptions): string {
               <span class="site-cover__tag">MIT</span>
               <span class="site-cover__tag">Vanilla CE</span>
             </div>
-            <h1 class="site-cover__headline">Web components<br />for ink &amp; paper.</h1>
+            <h1 class="site-cover__headline">Web components<br />for e-ink &amp; e-paper.</h1>
             <p class="site-cover__lede">
-              EPaper is a vanilla custom-element library tuned for e-paper displays. Surgical DOM
-              updates, no animations, no <code>:hover</code>, no Shadow DOM — just standards-based
-              components your design system can ship on a Kaleido panel today.
+              EPaper is a vanilla custom-element library tuned for e-ink and e-paper displays.
+              Surgical DOM updates, no animations, no <code>:hover</code>, no Shadow DOM — just
+              standards-based components your design system can ship on a Kaleido panel today.
             </p>
             <div class="site-cover__cta">
               <a class="ink-btn ink-btn--primary" href="${esc(withBase('/install/'))}">Get started</a>
@@ -116,6 +118,155 @@ function coverMain(opts: ContentOptions): string {
               <div class="site-cover__stat-value" data-site-stat="stars">${esc(opts.stars)}</div>
             </div>
           </div>
+        </div>
+${coverFoldHtml()}`;
+}
+
+/**
+ * The cover below the fold.
+ *
+ * The hero above is a masthead: three words, a lede and two buttons. That is
+ * the right first screen and the wrong whole document — a page carrying sixty
+ * words of prose has nothing for a search engine to match, which is how the
+ * FAQ came to outrank this page for the site's own subject. So the cover
+ * continues the way a broadsheet front page continues past the fold: the
+ * subject stated plainly, then the shortest honest route into every section
+ * that answers it in full.
+ *
+ * Deliberately not a copy of those sections. Each block here states its point
+ * in a couple of sentences and links onward; the depth stays on the page that
+ * owns it, so the cover and the section it points at are not two documents
+ * competing for the same query.
+ *
+ * Static markup rather than custom elements, for the reason at the top of this
+ * file: a crawler that does not run JavaScript has to see every word of it.
+ */
+function coverFoldHtml(): string {
+  const intro = HOME_INTRO.map(
+    (para) => `
+            <p class="site-lede">${inlineHtml(para)}</p>`,
+  ).join('');
+
+  const constraints = EINK_CONSTRAINTS.map(
+    (c) => `
+              <div class="site-home__def">
+                <dt class="site-home__term">${inlineHtml(c.term)}</dt>
+                <dd class="site-home__desc">${inlineHtml(c.def)}</dd>
+              </div>`,
+  ).join('');
+
+  // Counted rather than authored: the category tallies drift the moment a
+  // component is added, and a wrong number on the cover is worse than none.
+  const categories = CATEGORIES.filter((c) => c.value !== 'all')
+    .map((c) => {
+      const count = COMPONENTS.filter((entry) => entry.category === c.value).length;
+      return `
+            <a class="ink-link" href="${esc(withBase('/components/'))}">${esc(c.label)} (${esc(
+              String(count),
+            )})</a>`;
+    })
+    .join('');
+
+  const guides = articlesOfKind('guide')
+    .map(
+      (a) => `
+            <li class="site-home__item">
+              <a class="ink-link" href="${esc(withBase(articlePath(a)))}">${esc(a.heading)}</a>
+              <span class="site-home__item-desc">${esc(a.description)}</span>
+            </li>`,
+    )
+    .join('');
+
+  const recipes = articlesOfKind('recipe')
+    .map(
+      (a) => `
+            <a class="ink-link" href="${esc(withBase(articlePath(a)))}">${esc(a.heading)}</a>`,
+    )
+    .join('');
+
+  const questions = homeQuestions()
+    .map(
+      (item) => `
+            <div class="site-home__qa">
+              <h3 class="site-home__q">
+                <a class="ink-link" href="${esc(
+                  withBase('/faq/'),
+                )}#${esc(item.anchor)}">${esc(item.q)}</a>
+              </h3>
+              <p class="site-home__a">${inlineHtml(item.teaser)}</p>
+            </div>`,
+    )
+    .join('');
+
+  const answerCount = String(FAQ.reduce((n, group) => n + group.items.length, 0));
+
+  return `
+        <div class="site-home">
+          <section class="site-home__block" aria-labelledby="home-what">
+            <h2 class="ink-title ink-title--3" id="home-what">What EPaper is</h2>${intro}
+          </section>
+
+          <section class="site-home__block" aria-labelledby="home-eink">
+            <h2 class="ink-title ink-title--3" id="home-eink">
+              What makes a web component e-ink-ready
+            </h2>
+            <dl class="site-home__defs">${constraints}
+            </dl>
+            <p class="site-home__more">
+              <a class="ink-link" href="${esc(
+                withBase('/features/'),
+              )}">All six design principles →</a>
+            </p>
+          </section>
+
+          <section class="site-home__block" aria-labelledby="home-install">
+            <h2 class="ink-title ink-title--3" id="home-install">Install it</h2>
+            <pre class="site-code">${esc(INSTALL_SNIPPETS.npm)}</pre>
+            <pre class="site-code">${esc(IMPORT_SNIPPET)}</pre>
+            <p class="site-home__more">
+              <a class="ink-link" href="${esc(
+                withBase('/install/'),
+              )}">Quickstart, including pnpm and yarn →</a>
+            </p>
+          </section>
+
+          <section class="site-home__block" aria-labelledby="home-components">
+            <h2 class="ink-title ink-title--3" id="home-components">
+              ${esc(String(COMPONENTS.length))} components, one custom element each
+            </h2>
+            <p class="site-lede">
+              Buttons, inputs, pickers, tables, calendars and layout primitives — each a standalone
+              module, so a page that needs one component ships one component. The form controls are
+              form-associated: they submit through <code>FormData</code> and validate through
+              <code>ElementInternals</code> like native inputs do.
+            </p>
+            <nav class="site-linkrow" aria-label="Component categories">${categories}
+            </nav>
+          </section>
+
+          <section class="site-home__block" aria-labelledby="home-guides">
+            <h2 class="ink-title ink-title--3" id="home-guides">
+              How to build for e-ink
+            </h2>
+            <p class="site-lede">
+              Long-form explanations of the medium and the platform APIs underneath it. They are
+              useful whether or not you install EPaper.
+            </p>
+            <ul class="site-home__list">${guides}
+            </ul>
+            <p class="site-home__more">
+              Complete builds: <span class="site-home__inline">${recipes}</span>
+            </p>
+          </section>
+
+          <section class="site-home__block" aria-labelledby="home-faq">
+            <h2 class="ink-title ink-title--3" id="home-faq">Common questions</h2>${questions}
+            <p class="site-home__more">
+              <a class="ink-link" href="${esc(withBase('/faq/'))}">All ${esc(
+                answerCount,
+              )} answers →</a>
+            </p>
+          </section>
         </div>`;
 }
 
@@ -588,16 +739,6 @@ function faqMain(route: Route): string {
           )}/discussions" rel="noopener">discussions board</a> is the right place to ask.
         </p>
         ${groups}`;
-}
-
-/** Fragment id for a question, so an answer can be linked to directly. */
-function faqId(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]{1,300}/g, '-')
-    .replace(/^-{1,300}/, '')
-    .replace(/-{1,300}$/, '')
-    .slice(0, 60);
 }
 
 /* --------------------------------------------------------------------- *

--- a/apps/site/src/data.ts
+++ b/apps/site/src/data.ts
@@ -173,6 +173,60 @@ export const FEATURES: FeatureCard[] = [
   },
 ];
 
+/* --------------------------------------------------------------------- *
+ * Cover page — the copy below the fold
+ * --------------------------------------------------------------------- */
+
+/**
+ * The cover's opening prose.
+ *
+ * Lives here rather than inline in `content.ts` because `seo.ts` renders the
+ * same paragraphs into `/index.md` and `llms.txt`. The HTML page and its
+ * markdown twin must not be able to disagree about what the project is — that
+ * is the copy an answer engine quotes.
+ *
+ * Written answer-first, in the vocabulary people actually search with: "e-ink
+ * web components", both spellings of e-ink, and the concrete tag names. The
+ * first sentence has to stand alone as the answer to "what is this".
+ */
+export const HOME_INTRO: string[] = [
+  'EPaper is an open-source library of e-ink web components: 71 vanilla custom elements built for electrophoretic (e-ink, also spelled eink) panels rather than backlit screens. Every element is plain HTML — `<e-button>`, `<e-table>`, `<e-date-picker>` — so an e-paper dashboard, an electronic shelf label or a meeting-room display is written the way a web page is written, with no framework and no build plugin.',
+  'Web components suit e-ink precisely because the platform does the work. A custom element owns the DOM it renders, so it can patch a single text node when a value changes instead of rebuilding a subtree — and on an e-paper panel the size of that change *is* the cost of the refresh. Every component here is written to that constraint, and the ones that take input participate in `<form>` natively through `ElementInternals`.',
+  'None of it requires an e-ink device. The components render normally on any screen; the constraints the medium imposes — no animation, no hover, high contrast — simply produce a stark, print-like interface that also suits kiosks, embedded panels and low-distraction reading UIs.',
+];
+
+export interface EinkConstraint {
+  term: string;
+  def: string;
+}
+
+/**
+ * The four rules that make a component e-ink-ready.
+ *
+ * A deliberately shorter list than {@link FEATURES}: the cover states the
+ * medium's constraints, page 2 states the library's design principles. Both
+ * are true, but a cover that reprints the feature grid gives a reader — and a
+ * crawler — no reason to treat the two pages as different documents.
+ */
+export const EINK_CONSTRAINTS: EinkConstraint[] = [
+  {
+    term: 'No animations, no transitions',
+    def: 'An e-paper controller redraws in discrete waveform cycles, not frames. A 300 ms fade is not a gradient on e-ink — it is a few dozen full-region refreshes queued faster than the panel can drain them. `base.css` resets both globally inside `.ink-page`.',
+  },
+  {
+    term: 'No `:hover` states',
+    def: 'E-ink devices are touch- or button-driven and have no pointer, so anything hidden behind `:hover` is unreachable. State is carried by `:focus-visible`, `[aria-selected]`, `[aria-checked]` and `[data-active]` instead.',
+  },
+  {
+    term: 'Surgical DOM updates',
+    def: 'Components patch text nodes and attributes in place and compare before writing, keeping the damaged rectangle small enough for the controller to pick a fast partial refresh over a full GC16 flash. See [how partial refresh works](/guides/partial-refresh/).',
+  },
+  {
+    term: 'No Shadow DOM',
+    def: 'Light DOM only, themed through one layer of CSS custom properties, so a panel vendor can restyle the whole set without touching JavaScript — and so a crawler reads the text without traversing a shadow root.',
+  },
+];
+
 export interface RoadmapItem {
   time: string;
   title: string;

--- a/apps/site/src/faq.ts
+++ b/apps/site/src/faq.ts
@@ -297,3 +297,71 @@ return <e-input ref={ref} label="Name" />;`,
 export function faqItems(): FaqItem[] {
   return FAQ.flatMap((group) => group.items);
 }
+
+/**
+ * Fragment id for a question or a group title, so an answer can be linked to
+ * directly.
+ *
+ * Exported from here rather than from `content.ts` because the cover links
+ * into this page by anchor and the markdown twin has to produce the same id.
+ * One implementation, or the two drift and the deep links rot silently.
+ */
+export function faqId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]{1,300}/g, '-')
+    .replace(/^-{1,300}/, '')
+    .replace(/-{1,300}$/, '')
+    .slice(0, 60);
+}
+
+/**
+ * The handful of questions the cover surfaces.
+ *
+ * Keyed by the exact question text so {@link homeQuestions} can fail the build
+ * if one is reworded here and not there — a cover linking to `/faq/#…` that no
+ * longer exists is a dead anchor no test would otherwise catch.
+ *
+ * The teaser is written for the cover, not copied from the answer. Reprinting
+ * the FAQ's paragraphs would put the same text on two indexed URLs, which is
+ * the thing this page is trying to stop doing.
+ */
+const HOME_QUESTIONS: Array<{ q: string; teaser: string }> = [
+  {
+    q: 'What is EPaper?',
+    teaser:
+      'An MIT-licensed set of 71 web components for e-paper and e-ink displays, published as `@marcomattes/epaper-components`.',
+  },
+  {
+    q: 'Do I need an e-paper display to use this?',
+    teaser:
+      'No. The components render on any screen — the e-ink rules just produce a stark, print-like interface.',
+  },
+  {
+    q: 'Do I need a build step or a framework?',
+    teaser:
+      'No. The elements register on import and upgrade tags already in the document, so one `<script type="module">` is enough.',
+  },
+  {
+    q: 'How big is it?',
+    teaser: 'About 40 KB gzipped for all 71 components; a single component is far smaller.',
+  },
+];
+
+export interface HomeQuestion {
+  q: string;
+  teaser: string;
+  /** Fragment id of the full answer on `/faq/`. */
+  anchor: string;
+}
+
+/** The cover's question list, with every anchor checked against the real FAQ. */
+export function homeQuestions(): HomeQuestion[] {
+  const known = new Set(faqItems().map((item) => item.q));
+  return HOME_QUESTIONS.map((entry) => {
+    if (!known.has(entry.q)) {
+      throw new Error(`faq: cover question "${entry.q}" is not in FAQ`);
+    }
+    return { q: entry.q, teaser: entry.teaser, anchor: faqId(entry.q) };
+  });
+}

--- a/apps/site/src/routes.ts
+++ b/apps/site/src/routes.ts
@@ -53,10 +53,15 @@ export const ROUTES: Route[] = [
     path: '/',
     dir: '',
     nav: 'Cover',
-    title: 'EPaper — Web Components for E-Paper Displays',
+    // The head term this page competes for is "e-ink web components", and it
+    // has to appear as that phrase — in the title, in the <h1> and in the
+    // first paragraph of the body. Before that was true the FAQ outranked
+    // the cover for the site's own subject, simply because the FAQ was the
+    // only page that spelled "e-ink" next to "web components" in prose.
+    title: 'EPaper — E-Ink Web Components for E-Paper Displays',
     description:
-      'A vanilla custom-element library tuned for e-paper and e-ink displays: surgical DOM updates, no animations, no :hover, no Shadow DOM. 71 framework-agnostic components in 40 KB gzipped, MIT licensed.',
-    heading: 'Web components for ink & paper.',
+      'EPaper is an open-source library of 71 e-ink web components: vanilla custom elements for e-paper (eink) displays, with surgical DOM updates, no animations, no :hover and no Shadow DOM. 40 KB gzipped, MIT licensed.',
+    heading: 'Web components for e-ink & e-paper.',
     folio: '01',
   },
   {

--- a/apps/site/src/seo.ts
+++ b/apps/site/src/seo.ts
@@ -25,10 +25,12 @@ import {
 } from './routes';
 import { ARTICLES, articlePath, articlesOfKind, readingMinutes, type Article } from './articles';
 import { blocksMarkdown } from './blocks';
-import { FAQ, faqItems } from './faq';
+import { FAQ, faqItems, homeQuestions } from './faq';
 import {
   COMPONENTS,
+  EINK_CONSTRAINTS,
   FEATURES,
+  HOME_INTRO,
   IMPORT_SNIPPET,
   INSTALL_SNIPPETS,
   ROADMAP,
@@ -67,6 +69,8 @@ function softwareGraph(version: string): Record<string, unknown> {
     maintainer: AUTHOR,
     url: SITE_ORIGIN,
     keywords: [
+      'e-ink web components',
+      'e-paper web components',
       'web components',
       'custom elements',
       'e-paper',
@@ -226,6 +230,57 @@ function guidesGraph(): Record<string, unknown>[] {
   ];
 }
 
+/**
+ * Structured data for the cover.
+ *
+ * The cover used to contribute nothing beyond the graph every page carries,
+ * which made it the least described page on a site about the thing it
+ * describes. Two additions, both restating text now visible on the page:
+ *
+ *   • `SoftwareApplication` — the type an engine resolves when someone asks
+ *     for a library rather than for a repository. `SoftwareSourceCode` (in
+ *     the shared graph) answers "where is the code"; this answers "what do I
+ *     install, and what does it cost", which is the question behind the
+ *     query.
+ *   • `ItemList` of the sections — the site's own shape, stated once on the
+ *     page that should be entered first. It is what a sitelinks block is
+ *     built from.
+ */
+function homeGraph(): Record<string, unknown>[] {
+  return [
+    {
+      '@type': 'SoftwareApplication',
+      '@id': `${SITE_ORIGIN}/#app`,
+      name: SITE_NAME,
+      alternateName: PACKAGE_NAME,
+      applicationCategory: 'DeveloperApplication',
+      applicationSubCategory: 'Web component library',
+      operatingSystem: 'Any browser with custom elements and ElementInternals',
+      description:
+        'A library of 71 e-ink web components: vanilla custom elements for e-paper displays, with surgical DOM updates, no animations, no :hover states and no Shadow DOM.',
+      softwareRequirements: 'Evergreen Chrome, Edge, Firefox or Safari 16.4+',
+      featureList: FEATURES.map((f) => f.title),
+      isBasedOn: { '@id': `${SITE_ORIGIN}/#software` },
+      author: AUTHOR,
+      // Free and MIT — stated because "is it free" is a question an engine
+      // answers from the offer, not from the licence URL.
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+      license: 'https://spdx.org/licenses/MIT.html',
+    },
+    {
+      '@type': 'ItemList',
+      name: 'EPaper documentation',
+      itemListElement: ROUTES.filter((r) => r.dir !== '').map((r, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: r.nav,
+        description: r.description,
+        url: absoluteUrl(r.path),
+      })),
+    },
+  ];
+}
+
 /** Route-specific structured data — the part an answer engine can cite. */
 function routeGraph(
   route: Route,
@@ -235,6 +290,8 @@ function routeGraph(
   if (route.article) return [articleGraph(route, route.article)];
 
   switch (route.dir) {
+    case '':
+      return homeGraph();
     case 'guides':
       return guidesGraph();
     case 'faq':
@@ -344,11 +401,18 @@ export function routeMarkdown(route: Route, opts: { version: string; stars: stri
   const lines = [`# ${route.title}`, '', route.description, '', `Canonical: ${canonical}`, ''];
 
   switch (route.dir) {
+    // The cover's markdown twin carries the same prose the page does. It used
+    // to be a two-sentence summary, which meant an engine following the
+    // markdown alternate saw a thinner home page than a browser did — and the
+    // alternate is the copy it quotes.
     case '':
       lines.push(
-        '## Summary',
+        '## What EPaper is',
         '',
-        `EPaper is a vanilla custom-element library tuned for e-paper displays. It ships ${COMPONENTS.length} components, no Shadow DOM, no animations and no \`:hover\`-only UI states.`,
+        ...HOME_INTRO.flatMap((para) => [para, '']),
+        '## What makes a web component e-ink-ready',
+        '',
+        ...EINK_CONSTRAINTS.map((c) => `- **${plainText(c.term)}**: ${c.def}`),
         '',
         '## Install',
         '',
@@ -359,6 +423,16 @@ export function routeMarkdown(route: Route, opts: { version: string; stars: stri
         '```js',
         IMPORT_SNIPPET,
         '```',
+        '',
+        `## Components (${COMPONENTS.length})`,
+        '',
+        `Every component is a standalone custom element with its own sub-path export. Form controls are form-associated: they submit through \`FormData\` and validate through \`ElementInternals\`. Full inventory: ${absoluteUrl('/components/')}`,
+        '',
+        '## Common questions',
+        '',
+        ...homeQuestions().map(
+          (item) => `- **${item.q}** ${item.teaser} — ${absoluteUrl('/faq/')}#${item.anchor}`,
+        ),
       );
       break;
     case 'features':
@@ -503,6 +577,12 @@ export function headHtml(
       description: route.description,
       isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
       about: { '@id': `${SITE_ORIGIN}/#software` },
+      // Only the cover claims the library as its *primary* entity. Every page
+      // is `about` it; saying "this page is the one that is it" on all of them
+      // would be the same non-answer the graph already gives.
+      ...(route.dir === '' && !notFound
+        ? { mainEntity: { '@id': `${SITE_ORIGIN}/#software` } }
+        : {}),
       inLanguage: 'en',
     },
     softwareGraph(opts.version),
@@ -653,8 +733,9 @@ export function llmsTxt(opts: { version: string; stars: string }): string {
 
   return `# ${SITE_NAME}
 
-> A vanilla custom-element library for e-paper displays. ${COMPONENTS.length} framework-agnostic
-> components in about 40 KB gzipped, MIT licensed, zero runtime dependencies.
+> A vanilla custom-element library of e-ink web components. ${COMPONENTS.length}
+> framework-agnostic components for e-paper displays in about 40 KB gzipped, MIT
+> licensed, zero runtime dependencies.
 
 EPaper is built for electrophoretic (e-ink) panels rather than backlit screens. The
 constraints that follow from that are deliberate and apply to every component:

--- a/apps/site/src/site.css
+++ b/apps/site/src/site.css
@@ -228,6 +228,113 @@ body {
   text-decoration: none;
 }
 
+/* ---------- Page 1 below the fold ---------- */
+/* The hero above keeps the whole first screen (.site-cover is flex: 1 inside
+   the section); everything here starts after it, the way a front page
+   continues past the fold. Generous top margin so the break is deliberate
+   rather than a paragraph that happened to overflow. */
+.site-home {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-7);
+  margin-top: var(--ink-space-8);
+  border-top: var(--ink-border-strong);
+  padding-top: var(--ink-space-6);
+}
+.site-home__block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-4);
+}
+.site-home__more {
+  font-family: var(--ink-mono);
+  font-size: var(--ink-text-small);
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+.site-home__inline {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--ink-space-3);
+}
+
+/* The e-ink constraints. A rule between terms rather than around each one:
+   this is a list of four things, not four cards. The 440px floor is what
+   makes four items a 2x2 block at the 1180px page width instead of a 3+1
+   with an orphan on the second row. */
+.site-home__defs {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 440px), 1fr));
+  gap: var(--ink-space-5);
+}
+.site-home__def {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-2);
+  border-top: var(--ink-border);
+  padding-top: var(--ink-space-3);
+}
+.site-home__term {
+  font-family: var(--ink-sans);
+  font-size: var(--ink-text-body);
+  font-weight: 700;
+  line-height: 1.3;
+}
+.site-home__desc {
+  font-family: var(--ink-serif);
+  font-size: var(--ink-text-body);
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* Guide list: heading and blurb on their own lines, hanging off a rule. */
+.site-home__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-4);
+  max-width: 72ch;
+}
+.site-home__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-1);
+  border-left: var(--ink-border);
+  padding-left: var(--ink-space-4);
+}
+.site-home__item-desc {
+  font-family: var(--ink-serif);
+  font-size: var(--ink-text-body);
+  line-height: 1.55;
+}
+
+/* Question teasers. Same shape as the FAQ page's items, one size smaller —
+   the full answers live there, these are signposts. */
+.site-home__qa {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ink-space-2);
+  border-left: var(--ink-border);
+  padding-left: var(--ink-space-4);
+  max-width: 72ch;
+}
+.site-home__q {
+  font-family: var(--ink-sans);
+  font-size: var(--ink-text-body);
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0;
+}
+.site-home__a {
+  font-family: var(--ink-serif);
+  font-size: var(--ink-text-body);
+  line-height: 1.55;
+  margin: 0;
+}
+
 /* ---------- Page navigation (footbar) ---------- */
 .site-pagenav {
   display: flex;


### PR DESCRIPTION
## Summary

The cover page (`/`) ranked behind the FAQ for the site's own head term. The cause is visible in the built HTML: the cover carried about **60 words** of body text — a headline, a lede, two buttons, three statistics — and the FAQ was the only page that spelled "e-ink" next to "web components" in prose. The page that should be the entry point had the least to match on.

This keeps the first screen exactly as it was and continues below the fold, the way a broadsheet front page continues: what EPaper is, the four constraints that make a component e-ink-ready, the install snippets, the component categories, the guides, and four question teasers. Each block states its point in a couple of sentences and links onward, so the cover and the section it points at are not two documents competing for one query.

The cover's `<main>` now renders **795 words**, up from ~60.

Changes:

- **`routes.ts`** — cover `title`, `description` and `heading` name e-ink as well as e-paper. Title is now `EPaper — E-Ink Web Components for E-Paper Displays`; the `<h1>` reads `Web components for e-ink & e-paper.`
- **`data.ts`** — new `HOME_INTRO` (three answer-first paragraphs) and `EINK_CONSTRAINTS` (the four rules of the medium). Deliberately not a reprint of `FEATURES`: page 2 states the library's design principles, the cover states the medium's constraints.
- **`faq.ts`** — `faqId()` moved here and exported (the cover deep-links into `/faq/#…`, and the markdown twin has to produce the same ids). New `homeQuestions()` resolves each cover question against the real FAQ and **throws at build time** if one is reworded, so a dead anchor fails the build instead of shipping. The teasers are written for the cover rather than copied, so the same paragraphs are not on two indexed URLs.
- **`content.ts`** — `coverFoldHtml()` renders the new sections as static markup (no custom elements, per the note at the top of that file: a crawler that does not run JS has to see every word). Category tallies and the answer count are computed, not authored.
- **`seo.ts`** — the cover's structured data gains `SoftwareApplication` (what to install, and that it is free — `SoftwareSourceCode` answers "where is the code", not "what do I install") and an `ItemList` of the site's sections. The cover's `WebPage` names the library as its `mainEntity`. `routeMarkdown` for `/` now mirrors the page, so `/index.md` and `llms.txt` are no longer thinner than the HTML.
- **`site.css`** — `.site-home*` styles for the new blocks. No transitions, no animations, no `:hover`.

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed — site content plus its markdown/`llms.txt` twins; no library code touched
- [x] CSS output builds locally (`npm run build`)

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm run build`
- [x] `npm run build:site` — 38 files written; verified in the built output that all four `/faq/#…` anchors resolve to real ids on the FAQ page, that the JSON-LD parses (`WebSite`, `WebPage`, `SoftwareSourceCode`, `BreadcrumbList`, `SoftwareApplication`, `ItemList`), and that `index.md` carries the same prose as the page
- [x] Rendered at 1280px and 390px in Chromium: no horizontal overflow at either width

## Notes

**Not a hard ranking guarantee.** This fixes the two things that are actually in our control — the page had no keyword-bearing text and almost no text at all. Whether the cover overtakes the FAQ depends on how Google reweighs the site after a recrawl, and that takes weeks. Worth watching in Search Console rather than declaring done.

**The FAQ is deliberately untouched.** It ranks because it earned it; the fix is to make the cover competitive, not to weaken the page that works.

**E-ink considerations:** no transitions, animations or `:hover` in the new CSS; the added markup is static HTML with no custom elements, so nothing new renders client-side and the cover still paints in one pass.

**Two judgement calls worth a second opinion:**

1. The cover is a deliberate full-height "cover of a paper" and this puts 700 words underneath it. `.site-cover` keeps `flex: 1`, so the first screen is unchanged and the new content starts after a strong rule — but it is a change in what the page *is*, and that is an editorial call, not a technical one.
2. The nav label for `/` is still `Cover`, so every internal link to the home page uses that as anchor text. `Home` would be worth more to a crawler and less to the metaphor; left as-is on purpose.

---
_Generated by [Claude Code](https://claude.ai/code/session_015b3ZrHeiREANLHyzyujXkT)_