### PR TITLE
Fix Storybook table rendering and component version tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Storybook's Introduction page rendered its markdown tables as a flat run
+  of pipe-separated text instead of actual `<table>`s — addon-docs' MDX
+  compiler doesn't enable GitHub-Flavored Markdown by default. `remark-gfm`
+  is now wired into `.storybook/main.ts`.
+- Every component's autodocs page opened with a `**Version:** vX.Y.Z` line
+  folded into the description paragraph — unstyled bold text with no
+  indication it referred to the library's release, easy to misread as a
+  per-component version. It's now a bordered tag reading "Since vX.Y.Z"
+  above the description, via `parameters.docs.subtitle`.
 - Composite form controls reported `aria-invalid` on their own anchor — a
   select trigger, a radiogroup, a drop zone — and no CSS rule targeted any of
   them. On a greyscale panel with no colour and no animation, a rejected

--- a/apps/storybook/.storybook/docs.css
+++ b/apps/storybook/.storybook/docs.css
@@ -1,0 +1,32 @@
+/* Storybook-only chrome, not part of the shipped library styles.
+ *
+ * addon-docs renders `parameters.docs.subtitle` inside a bare `<h2
+ * class="sbdocs-subtitle sb-unstyled">`. Every autodoc'd component sets that
+ * subtitle to "Since vX.Y.Z", so left unstyled it reads as a second title
+ * rather than a version marker. Restyle it as an e-paper tag (the same look
+ * as `.ink-tag`) so it visually reads as one line per doc page, not a
+ * component-specific version scheme.
+ */
+/* addon-docs injects the default Subtitle look (20px h2, a bottom-only
+ * divider border, fixed line-height) via a runtime <style> tag that lands
+ * after this stylesheet in the cascade, so it wins per-property on anything
+ * left un-`!important`-ed here — including individual longhands like
+ * `border-bottom` even though this rule sets the `border` shorthand. Without
+ * `!important` the two rules blend into an open-bottomed box with oversized
+ * text that reads as "cut off" rather than a tag. */
+.sbdocs-subtitle {
+  display: inline-flex !important;
+  align-items: center !important;
+  width: auto !important;
+  height: auto !important;
+  margin: 0 0 24px !important;
+  padding: 2px 8px !important;
+  border: var(--ink-border, 1px solid currentColor) !important;
+  font-family: var(--ink-mono, ui-monospace, monospace) !important;
+  font-size: 11px !important;
+  line-height: 1.4 !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase !important;
+  color: var(--ink-fg, currentColor) !important;
+}

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,3 +1,4 @@
+import remarkGfm from 'remark-gfm';
 import type { StorybookConfig } from '@storybook/web-components-vite';
 
 // Stories live in packages/epaper-components/src/stories — co-located with
@@ -9,7 +10,23 @@ const config: StorybookConfig = {
     '../../../packages/epaper-components/src/stories/**/*.mdx',
   ],
   framework: '@storybook/web-components-vite',
-  addons: ['@storybook/addon-a11y', '@storybook/addon-docs', '@storybook/addon-vitest'],
+  addons: [
+    '@storybook/addon-a11y',
+    // GFM tables and strikethrough aren't enabled by default in addon-docs'
+    // MDX compiler — without this, `| a | b |` tables in .mdx files render
+    // as a flat run of text instead of an actual <table>.
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        mdxPluginOptions: {
+          mdxCompileOptions: {
+            remarkPlugins: [remarkGfm],
+          },
+        },
+      },
+    },
+    '@storybook/addon-vitest',
+  ],
   // No `docs.autodocs` — it was removed in Storybook 8; stories opt in with
   // `tags: ['autodocs']` instead, which every story in src/stories already does.
   async viteFinal(config) {

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -6,6 +6,9 @@ import { html } from 'lit';
 import '../../../packages/epaper-components/src/styles/tokens.css';
 import '../../../packages/epaper-components/src/styles/base.css';
 import '../../../packages/epaper-components/src/styles/components.css';
+// Storybook-only chrome (restyles addon-docs' Subtitle block) — not shipped
+// with the library.
+import './docs.css';
 
 // Side-effect import: registers every `e-*` custom element once for all stories.
 import '../../../packages/epaper-components/src/index';

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "lit": "3.3.3",
         "playwright": "1.62.1",
         "prettier": "3.9.6",
+        "remark-gfm": "4.0.1",
         "size-limit": "13.0.3",
         "storybook": "10.5.10",
         "stylelint": "17.14.1",
@@ -3528,6 +3529,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3580,10 +3591,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mdx": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
       "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3650,6 +3678,13 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4629,6 +4664,17 @@
         }
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5248,6 +5294,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -5288,6 +5345,17 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/check-error": {
       "version": "2.1.3",
@@ -5939,6 +6007,20 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -6148,6 +6230,20 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -8789,6 +8885,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-running": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
@@ -9660,6 +9769,17 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -9773,6 +9893,17 @@
         "url": "https://github.com/fisker/make-synchronized?sponsor=1"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -9805,6 +9936,219 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -9843,6 +10187,597 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -11501,6 +12436,58 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -13347,6 +14334,17 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -13481,6 +14479,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unique-string": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -13495,6 +14513,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unplugin": {
@@ -13645,6 +14722,36 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -14359,6 +15466,17 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/epaper-components": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lit": "3.3.3",
     "playwright": "1.62.1",
     "prettier": "3.9.6",
+    "remark-gfm": "4.0.1",
     "size-limit": "13.0.3",
     "storybook": "10.5.10",
     "stylelint": "17.14.1",

--- a/packages/epaper-components/src/stories/Tokens.stories.ts
+++ b/packages/epaper-components/src/stories/Tokens.stories.ts
@@ -38,9 +38,10 @@ const meta: Meta = {
   parameters: {
     layout: 'padded',
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSingle source of truth for the visual system. Every component reads from these CSS custom properties — never hard-coded values — so re-skinning the library is a matter of overriding tokens at the page or component level. The system is intentionally narrow: no light/dark theme, no semantic alias layer, only five accent colors.',
+          'Single source of truth for the visual system. Every component reads from these CSS custom properties — never hard-coded values — so re-skinning the library is a matter of overriding tokens at the page or component level. The system is intentionally narrow: no light/dark theme, no semantic alias layer, only five accent colors.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/composite/FloatButton.stories.ts
+++ b/packages/epaper-components/src/stories/composite/FloatButton.stories.ts
@@ -9,9 +9,10 @@ const meta: Meta = {
   parameters: {
     layout: 'fullscreen',
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nFixed-position circular action button anchored to a viewport corner. Surfaces a top-priority action (e.g. compose, add) without taking space in the document flow.',
+          'Fixed-position circular action button anchored to a viewport corner. Surfaces a top-priority action (e.g. compose, add) without taking space in the document flow.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/composite/Form.stories.ts
+++ b/packages/epaper-components/src/stories/composite/Form.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nForm layout with consistent label/control rows, hint text and validation messaging. Use `stacked` for most cases and `inline` for filter bars or single-row queries.',
+          'Form layout with consistent label/control rows, hint text and validation messaging. Use `stacked` for most cases and `inline` for filter bars or single-row queries.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/composite/Upload.stories.ts
+++ b/packages/epaper-components/src/stories/composite/Upload.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nFile upload control with both click-to-browse and drag-and-drop targets, plus an inline file list. Restrict file types via the `accept` attribute and toggle `multiple` for batch uploads.',
+          'File upload control with both click-to-browse and drag-and-drop targets, plus an inline file list. Restrict file types via the `accept` attribute and toggle `multiple` for batch uploads.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Agenda.stories.ts
+++ b/packages/epaper-components/src/stories/display/Agenda.stories.ts
@@ -30,9 +30,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nDay or week agenda on a proportional time axis. Entries are the same `{date, title, start?, end?, status?}` objects `<e-calendar>` reads, so one dataset feeds both. Free stretches are labelled rather than left blank, and the "now" marker is drawn only from the `now` attribute — the component owns no timer.',
+          'Day or week agenda on a proportional time axis. Entries are the same `{date, title, start?, end?, status?}` objects `<e-calendar>` reads, so one dataset feeds both. Free stretches are labelled rather than left blank, and the "now" marker is drawn only from the `now` attribute — the component owns no timer.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Avatar.stories.ts
+++ b/packages/epaper-components/src/stories/display/Avatar.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nUser or entity portrait. Falls back from image (`src`) to derived initials based on `name`. Supports any pixel size and either a `square` or `circle` shape.',
+          'User or entity portrait. Falls back from image (`src`) to derived initials based on `name`. Supports any pixel size and either a `square` or `circle` shape.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Barcode.stories.ts
+++ b/packages/epaper-components/src/stories/display/Barcode.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nEAN-13, EAN-8, UPC-A and Code 128 rendered as inline SVG by a self-contained encoder — the same construction as `<e-qrcode>`: zero runtime dependencies, one white rect plus one dark path, `shape-rendering="crispEdges"`. A missing check digit is computed; a wrong one is reported.',
+          'EAN-13, EAN-8, UPC-A and Code 128 rendered as inline SVG by a self-contained encoder — the same construction as `<e-qrcode>`: zero runtime dependencies, one white rect plus one dark path, `shape-rendering="crispEdges"`. A missing check digit is computed; a wrong one is reported.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Calendar.stories.ts
+++ b/packages/epaper-components/src/stories/display/Calendar.stories.ts
@@ -15,9 +15,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nMonth-grid date display. Read-only by default; supply `events` (a JSON array of `{ date, title }`) to mark dated entries. Useful for editorial calendars, schedules and date overviews.',
+          'Month-grid date display. Read-only by default; supply `events` (a JSON array of `{ date, title }`) to mark dated entries. Useful for editorial calendars, schedules and date overviews.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Card.stories.ts
+++ b/packages/epaper-components/src/stories/display/Card.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nFramed container with optional eyebrow, title and slotted body content. Uses the standard 2 px ink border so cards line up with the rest of the system.',
+          'Framed container with optional eyebrow, title and slotted body content. Uses the standard 2 px ink border so cards line up with the rest of the system.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/CardImage.stories.ts
+++ b/packages/epaper-components/src/stories/display/CardImage.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nCard variant with a leading hero region — either an image URL or the built-in diagonal `hatch` cover for editorial layouts. Pairs well with Ribbon for featured items.',
+          'Card variant with a leading hero region — either an image URL or the built-in diagonal `hatch` cover for editorial layouts. Pairs well with Ribbon for featured items.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/ChangeMarker.stories.ts
+++ b/packages/epaper-components/src/stories/display/ChangeMarker.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nCompact current value with a persistent text-and-pattern cue only when it differs from `previous`.',
+          'Compact current value with a persistent text-and-pattern cue only when it differs from `previous`.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Collapse.stories.ts
+++ b/packages/epaper-components/src/stories/display/Collapse.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nStack of expandable sections built on native `<details>`/`<summary>`. Expanding a section mutates one `open` attribute, so the panel repaints only the section that changed instead of reflowing the page — which is what makes a collapse a better fit than a scrolling wall of text on e-paper. Keyboard support, the accessible name and find-in-page all come from the native element.',
+          'Stack of expandable sections built on native `<details>`/`<summary>`. Expanding a section mutates one `open` attribute, so the panel repaints only the section that changed instead of reflowing the page — which is what makes a collapse a better fit than a scrolling wall of text on e-paper. Keyboard support, the accessible name and find-in-page all come from the native element.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/DescriptionList.stories.ts
+++ b/packages/epaper-components/src/stories/display/DescriptionList.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSemantic key/value list rendered with a `<dl>`. Prefer this over a raw `<dl>` when you want consistent layout, optional borders and a multi-column grid.',
+          'Semantic key/value list rendered with a `<dl>`. Prefer this over a raw `<dl>` when you want consistent layout, optional borders and a multi-column grid.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Diff.stories.ts
+++ b/packages/epaper-components/src/stories/display/Diff.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nPersistent previous/current comparison. Both values remain visible and the current state receives a patterned cue when changed.',
+          'Persistent previous/current comparison. Both values remain visible and the current state receives a patterned cue when changed.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Empty.stories.ts
+++ b/packages/epaper-components/src/stories/display/Empty.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nEmpty-state placeholder with icon, title, optional description and an action slot. Use as the body of a list, table or section that has no content yet.',
+          'Empty-state placeholder with icon, title, optional description and an action slot. Use as the body of a list, table or section that has no content yet.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/EventLog.stories.ts
+++ b/packages/epaper-components/src/stories/display/EventLog.stories.ts
@@ -40,9 +40,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nKeyed, append-only event and alarm list. Rows are identified by `id`: a new event is inserted as a single node and an existing row is patched in place, so a live log costs a partial refresh of one row instead of a full-page flash. Use `appendEntries()` to push, `acknowledge(id)` to mark one row, `clear()` to empty it.',
+          'Keyed, append-only event and alarm list. Rows are identified by `id`: a new event is inserted as a single node and an existing row is patched in place, so a live log costs a partial refresh of one row instead of a full-page flash. Use `appendEntries()` to push, `acknowledge(id)` to mark one row, `clear()` to empty it.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Image.stories.ts
+++ b/packages/epaper-components/src/stories/display/Image.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nImage wrapper with native lazy-loading, fallback source and optional caption. On error, swaps to `fallback`; if that fails too, shows a hatched placeholder.',
+          'Image wrapper with native lazy-loading, fallback source and optional caption. On error, swaps to `fallback`; if that fails too, shows a hatched placeholder.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Kaleido.stories.ts
+++ b/packages/epaper-components/src/stories/display/Kaleido.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nShowcase swatch for the five Kaleido accent colors (red, orange, yellow, green, blue). These are the **only** fills permitted in the system and are reserved for state — destructive, warning, attention, success, link/info.',
+          'Showcase swatch for the five Kaleido accent colors (red, orange, yellow, green, blue). These are the **only** fills permitted in the system and are reserved for state — destructive, warning, attention, success, link/info.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/LastUpdated.stories.ts
+++ b/packages/epaper-components/src/stories/display/LastUpdated.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nRelative update age with fresh, stale and expired states. It owns no timer: set `now` from the application refresh cycle or call `refresh()` explicitly.',
+          'Relative update age with fresh, stale and expired states. It owns no timer: set `now` from the application refresh cycle or call `refresh()` explicitly.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/List.stories.ts
+++ b/packages/epaper-components/src/stories/display/List.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nStructured list with optional header / footer slots and slot-driven `<e-list-item>` rows. Use this instead of a native `<ul>` when you need leading / trailing content per row.',
+          'Structured list with optional header / footer slots and slot-driven `<e-list-item>` rows. Use this instead of a native `<ul>` when you need leading / trailing content per row.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Meter.stories.ts
+++ b/packages/epaper-components/src/stories/display/Meter.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nDiscrete bounded measurement with explicit low, in-range and high cues. It uses segments and hatch patterns instead of animation or color-only status.',
+          'Discrete bounded measurement with explicit low, in-range and high cues. It uses segments and hatch patterns instead of animation or color-only status.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Popover.stories.ts
+++ b/packages/epaper-components/src/stories/display/Popover.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nClick-triggered overlay panel anchored to its trigger — the counterpart to a tooltip for hardware that has no hover. Capacitive e-paper digitizers report contact, not proximity, so anything that would be revealed on hover has to be revealed on tap instead. Content is arbitrary, which separates this from `<e-dropdown>` (a list of commands). The panel is non-modal and does not trap focus; reach for `<e-dialog>` when the user must deal with it before continuing.',
+          'Click-triggered overlay panel anchored to its trigger — the counterpart to a tooltip for hardware that has no hover. Capacitive e-paper digitizers report contact, not proximity, so anything that would be revealed on hover has to be revealed on tap instead. Content is arbitrary, which separates this from `<e-dropdown>` (a list of commands). The panel is non-modal and does not trap focus; reach for `<e-dialog>` when the user must deal with it before continuing.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Price.stories.ts
+++ b/packages/epaper-components/src/stories/display/Price.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nRetail price with the major unit set large and the minor unit small. Formatting goes through `Intl`, so the currency symbol lands where the locale puts it. `original` adds a struck-through previous price, `unit-price`/`unit` add the base price, and `size` scales the whole block from a 1.5" shelf label to a 10" panel.',
+          'Retail price with the major unit set large and the minor unit small. Formatting goes through `Intl`, so the currency symbol lands where the locale puts it. `original` adds a struck-through previous price, `unit-price`/`unit` add the base price, and `size` scales the whole block from a 1.5" shelf label to a 10" panel.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Progress.stories.ts
+++ b/packages/epaper-components/src/stories/display/Progress.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nStatic progress indicator. Renders as a linear bar or as discrete steps. No animation: the bar updates as a single dirty rectangle for partial-refresh-friendly behaviour.',
+          'Static progress indicator. Renders as a linear bar or as discrete steps. No animation: the bar updates as a single dirty rectangle for partial-refresh-friendly behaviour.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/QRCode.stories.ts
+++ b/packages/epaper-components/src/stories/display/QRCode.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nPure-SVG QR code renderer with zero runtime dependencies. Ideal for e-paper devices: every module is a sharp 1-bit cell.',
+          'Pure-SVG QR code renderer with zero runtime dependencies. Ideal for e-paper devices: every module is a sharp 1-bit cell.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Redline.stories.ts
+++ b/packages/epaper-components/src/stories/display/Redline.stories.ts
@@ -18,9 +18,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nWord-level diff between two text versions, with `<ins>`/`<del>` markup, a changed-paragraph summary and a "changes only" view.',
+          'Word-level diff between two text versions, with `<ins>`/`<del>` markup, a changed-paragraph summary and a "changes only" view.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Result.stories.ts
+++ b/packages/epaper-components/src/stories/display/Result.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nStatus page block (success / error / 404 / info / warning). Composes an icon, large title, optional description and a slotted action area.',
+          'Status page block (success / error / 404 / info / warning). Composes an icon, large title, optional description and a slotted action area.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Segmented.stories.ts
+++ b/packages/epaper-components/src/stories/display/Segmented.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSingle-select control rendered as a flat row of mutually-exclusive segments. Use it as a lightweight alternative to Tabs or RadioGroup when options are short labels.',
+          'Single-select control rendered as a flat row of mutually-exclusive segments. Use it as a lightweight alternative to Tabs or RadioGroup when options are short labels.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Skeleton.stories.ts
+++ b/packages/epaper-components/src/stories/display/Skeleton.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nStatic loading placeholder. Pure outline — no shimmer, no animation. Use to reserve space while content loads. Avoids triggering a full GC16 refresh on e-paper.',
+          'Static loading placeholder. Pure outline — no shimmer, no animation. Use to reserve space while content loads. Avoids triggering a full GC16 refresh on e-paper.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Sparkline.stories.ts
+++ b/packages/epaper-components/src/stories/display/Sparkline.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nMonochrome SVG mini-chart. The first-to-last trend is repeated as a glyph and readable text, and updates replace only the polyline coordinates.',
+          'Monochrome SVG mini-chart. The first-to-last trend is repeated as a glyph and readable text, and updates replace only the polyline coordinates.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Statistic.stories.ts
+++ b/packages/epaper-components/src/stories/display/Statistic.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nKPI block: large numeric value with label and an optional trend marker. The trend glyph is static (no animation) so it does not provoke an e-paper full refresh.',
+          'KPI block: large numeric value with label and an optional trend marker. The trend glyph is static (no animation) so it does not provoke an e-paper full refresh.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/StatusBoard.stories.ts
+++ b/packages/epaper-components/src/stories/display/StatusBoard.stories.ts
@@ -17,9 +17,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nStable keyed KPI matrix. Replacing `data` patches existing cells in place when their keys are unchanged, keeping redraws local.',
+          'Stable keyed KPI matrix. Replacing `data` patches existing cells in place when their keys are unchanged, keeping redraws local.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/StatusPill.stories.ts
+++ b/packages/epaper-components/src/stories/display/StatusPill.stories.ts
@@ -14,9 +14,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nSingle-value status marker — the one-value counterpart to `StatusBoard`. Its vocabulary is open, so a door sign can say "Belegt" instead of bending occupancy onto `warning`. Every state renders a symbol *and* a word, so it stays readable on a greyscale panel.',
+          'Single-value status marker — the one-value counterpart to `StatusBoard`. Its vocabulary is open, so a door sign can say "Belegt" instead of bending occupancy onto `warning`. Every state renders a symbol *and* a word, so it stays readable on a greyscale panel.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Table.stories.ts
+++ b/packages/epaper-components/src/stories/display/Table.stories.ts
@@ -20,9 +20,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nData grid with header, optional sort and row selection. Sort is **static**: clicking a header cycles `none → asc → desc → none` and emits `e-sort` — owners decide whether to re-sort or re-fetch.',
+          'Data grid with header, optional sort and row selection. Sort is **static**: clicking a header cycles `none → asc → desc → none` and emits `e-sort` — owners decide whether to re-sort or re-fetch.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Tag.stories.ts
+++ b/packages/epaper-components/src/stories/display/Tag.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSmall inline label, optionally removable. Use to mark categories or filters that the user can dismiss. Distinct from `<e-badge>`, which is purely decorative.',
+          'Small inline label, optionally removable. Use to mark categories or filters that the user can dismiss. Distinct from `<e-badge>`, which is purely decorative.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Timeline.stories.ts
+++ b/packages/epaper-components/src/stories/display/Timeline.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nVertical event list with a hairline rail and bullet markers. Use for activity feeds, audit logs or order tracking. Static layout — no animations.',
+          'Vertical event list with a hairline rail and bullet markers. Use for activity feeds, audit logs or order tracking. Static layout — no animations.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/display/Tree.stories.ts
+++ b/packages/epaper-components/src/stories/display/Tree.stories.ts
@@ -27,9 +27,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nHierarchical tree for navigation and display — the counterpart to `<e-tree-select>`, sharing its markup and keyboard model (arrows, `Home`/`End`, `Enter`/`Space`) but not form-associated. Expanding a node materialises its children on first open and toggles `hidden` afterwards, so a deep tree costs one small dirty rectangle per interaction rather than a full re-render.',
+          'Hierarchical tree for navigation and display — the counterpart to `<e-tree-select>`, sharing its markup and keyboard model (arrows, `Home`/`End`, `Enter`/`Space`) but not form-associated. Expanding a node materialises its children on first open and toggles `hidden` afterwards, so a deep tree costs one small dirty rectangle per interaction rather than a full re-render.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/feedback/Alert.stories.ts
+++ b/packages/epaper-components/src/stories/feedback/Alert.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nInline status banner. The static counterpart to a toast — nothing appears or disappears on a timer, because a message that auto-dismisses can be missed entirely between two panel refreshes. Severity is carried by an icon, a border weight and a hatch fill, never by color alone. Use `<e-result>` instead when the message *is* the page.',
+          'Inline status banner. The static counterpart to a toast — nothing appears or disappears on a timer, because a message that auto-dismisses can be missed entirely between two panel refreshes. Severity is carried by an icon, a border weight and a hatch fill, never by color alone. Use `<e-result>` instead when the message *is* the page.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/feedback/Dialog.stories.ts
+++ b/packages/epaper-components/src/stories/feedback/Dialog.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.1.0',
       description: {
         component:
-          '**Version:** v1.1.0\n\nModal dialog built on the native `<dialog>` element, opened through `showModal()`. Focus trapping, `Escape` handling, the top layer and inertness of the page behind it come from the browser. A modal is a deliberate context switch, which is the one place a full-panel refresh is appropriate on e-paper — so the backdrop is a flat hatch fill, never a translucent wash, which would dither unpredictably between refreshes.',
+          'Modal dialog built on the native `<dialog>` element, opened through `showModal()`. Focus trapping, `Escape` handling, the top layer and inertness of the page behind it come from the browser. A modal is a deliberate context switch, which is the one place a full-panel refresh is appropriate on e-paper — so the backdrop is a flat hatch fill, never a translucent wash, which would dither unpredictably between refreshes.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/feedback/Popconfirm.stories.ts
+++ b/packages/epaper-components/src/stories/feedback/Popconfirm.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nInline confirmation bubble anchored to the control that triggers it. A lighter alternative to `<e-dialog>` for a single destructive action: no backdrop, no full-panel refresh, just a small dirty rectangle next to the button. Undo is expensive on e-paper, which makes confirming worth more than it is on desktop — but a full modal flash for a one-line question is not.',
+          'Inline confirmation bubble anchored to the control that triggers it. A lighter alternative to `<e-dialog>` for a single destructive action: no backdrop, no full-panel refresh, just a small dirty rectangle next to the button. Undo is expensive on e-paper, which makes confirming worth more than it is on desktop — but a full modal flash for a one-line question is not.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Cascader.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Cascader.stories.ts
@@ -41,9 +41,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nTiered select that drills into multi-level options column-by-column (e.g. country → region → city). The committed value is the full path joined with commas.',
+          'Tiered select that drills into multi-level options column-by-column (e.g. country → region → city). The committed value is the full path joined with commas.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Checkbox.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Checkbox.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSingle binary on/off control with a flat ink check. Pair with a label or compose multiple instances inside a CheckboxGroup.',
+          'Single binary on/off control with a flat ink check. Pair with a label or compose multiple instances inside a CheckboxGroup.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/CheckboxGroup.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/CheckboxGroup.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nCollection of related checkboxes managed as one form field. Lays out children either vertically (default) or horizontally, exposing the joined selection as a comma-separated string.',
+          'Collection of related checkboxes managed as one form field. Lays out children either vertically (default) or horizontally, exposing the joined selection as a comma-separated string.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Chip.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Chip.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSelectable label for filters or quick choices. Toggles `selected` on click and fires `e-change`. Distinct from `<e-tag>` (removable label) and `<e-badge>` (decorative).',
+          'Selectable label for filters or quick choices. Toggles `selected` on click and fires `e-change`. Distinct from `<e-tag>` (removable label) and `<e-badge>` (decorative).',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/DatePicker.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/DatePicker.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nText field paired with a popover month calendar for picking a single date. Values are exchanged as ISO `YYYY-MM-DD` strings.',
+          'Text field paired with a popover month calendar for picking a single date. Values are exchanged as ISO `YYYY-MM-DD` strings.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Input.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Input.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSingle-line text field with built-in label, placeholder, hint and error states. Setting `error` switches the border to the error treatment and wires `aria-invalid` automatically.',
+          'Single-line text field with built-in label, placeholder, hint and error states. Setting `error` switches the border to the error treatment and wires `aria-invalid` automatically.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/InputNumber.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/InputNumber.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nNumeric input with stepper buttons. Supports `min`, `max` and `step` constraints and clamps the value on commit.',
+          'Numeric input with stepper buttons. Supports `min`, `max` and `step` constraints and clamps the value on commit.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Keypad.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Keypad.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nOn-screen numeric keypad for kiosk browsers with no operating-system keyboard. It is a form control in its own right, and mirrors every key into the control named by `for`.',
+          'On-screen numeric keypad for kiosk browsers with no operating-system keyboard. It is a form control in its own right, and mirrors every key into the control named by `for`.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/PinInput.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/PinInput.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nFixed-length code entry as separate digit boxes. Typing advances, `Backspace` on an empty box steps back, and pasting a code fills every box at once. `inputmode="numeric"` brings up the numeric soft keyboard; `masked` hides the digits.',
+          'Fixed-length code entry as separate digit boxes. Typing advances, `Backspace` on an empty box steps back, and pasting a code fills every box at once. `inputmode="numeric"` brings up the numeric soft keyboard; `masked` hides the digits.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/RadioGroup.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/RadioGroup.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSingle-select control rendered as a list of radio options. Use when the user needs to see all available choices at once.',
+          'Single-select control rendered as a list of radio options. Use when the user needs to see all available choices at once.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Rating.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Rating.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nStar or smiley rating with 48px touch targets and full keyboard control (arrows, `Home`/`End`, digit keys). Form-associated: an unrated control submits an empty value, so `required` behaves like it does on a native control.',
+          'Star or smiley rating with 48px touch targets and full keyboard control (arrows, `Home`/`End`, digit keys). Form-associated: an unrated control submits an empty value, so `required` behaves like it does on a native control.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Select.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Select.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nDrop-down list for choosing one option from a closed set. Prefer over RadioGroup once the option count gets long enough that scanning becomes expensive (~6+ items).',
+          'Drop-down list for choosing one option from a closed set. Prefer over RadioGroup once the option count gets long enough that scanning becomes expensive (~6+ items).',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Signature.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Signature.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nSignature pad on a canvas. The drawn signature is submitted as a PNG `File`, exactly as an `<input type="file">` would post one, and a restored file is put back on the canvas. `clear()` wipes it; `fallback-text` covers a browser without a 2D canvas.',
+          'Signature pad on a canvas. The drawn signature is submitted as a PNG `File`, exactly as an `<input type="file">` would post one, and a restored file is put back on the canvas. `clear()` wipes it; `fallback-text` covers a browser without a 2D canvas.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Slider.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Slider.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nRange slider with a 28×36 grip, a printed value readout and optional tick marks. The value is always printed next to the track: a thumb position alone is not readable on a panel without sub-pixel rendering.',
+          'Range slider with a 28×36 grip, a printed value readout and optional tick marks. The value is always printed next to the track: a thumb position alone is not readable on a panel without sub-pixel rendering.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Textarea.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Textarea.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nMulti-line text field for longer-form input such as comments, descriptions or messages. Shares the Input visual treatment.',
+          'Multi-line text field for longer-form input such as comments, descriptions or messages. Shares the Input visual treatment.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/TimePicker.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/TimePicker.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nText field paired with an hour/minute popover for picking a time. Values are exchanged as 24-hour `HH:MM` strings.',
+          'Text field paired with an hour/minute popover for picking a time. Values are exchanged as 24-hour `HH:MM` strings.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/Toggle.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/Toggle.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nTwo-state switch for binary settings that take effect immediately. Use as an alternative to Checkbox in settings panels and toolbars.',
+          'Two-state switch for binary settings that take effect immediately. Use as an alternative to Checkbox in settings panels and toolbars.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/inputs/TreeSelect.stories.ts
+++ b/packages/epaper-components/src/stories/inputs/TreeSelect.stories.ts
@@ -36,9 +36,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSelect that exposes a hierarchical tree of options collapsible by branch. Useful for taxonomies, org charts or geo selectors where parent/child context matters.',
+          'Select that exposes a hierarchical tree of options collapsible by branch. Useful for taxonomies, org charts or geo selectors where parent/child context matters.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Affix.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Affix.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nWraps content in a CSS `position: sticky` container. Pure CSS — no scroll listeners, no e-paper waveform on scroll.',
+          'Wraps content in a CSS `position: sticky` container. Pure CSS — no scroll listeners, no e-paper waveform on scroll.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Divider.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Divider.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nHorizontal or vertical rule used to separate sections. Supports `solid` and `dashed` strokes and an optional centered inline label.',
+          'Horizontal or vertical rule used to separate sections. Supports `solid` and `dashed` strokes and an optional centered inline label.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Flex.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Flex.stories.ts
@@ -11,9 +11,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nOne-dimensional flexbox container. Exposes attributes for `direction`, `wrap`, `gap`, `justify` and `align` so layout stays declarative — no ad-hoc inline styles.',
+          'One-dimensional flexbox container. Exposes attributes for `direction`, `wrap`, `gap`, `justify` and `align` so layout stays declarative — no ad-hoc inline styles.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Grid.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Grid.stories.ts
@@ -16,9 +16,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nTwo-dimensional CSS-grid container. Compose with `<e-grid-item col="span N">` to lay out cells. Use the `cols` and `gap` attributes to drive the track count and spacing.',
+          'Two-dimensional CSS-grid container. Compose with `<e-grid-item col="span N">` to lay out cells. Use the `cols` and `gap` attributes to drive the track count and spacing.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Layout.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Layout.stories.ts
@@ -9,9 +9,10 @@ const meta: Meta = {
   parameters: {
     layout: 'fullscreen',
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nPage chrome scaffold composed of optional `<e-header>`, `<e-sider>`, `<e-content>` and `<e-footer>` regions. Provides the top-level frame for application screens.',
+          'Page chrome scaffold composed of optional `<e-header>`, `<e-sider>`, `<e-content>` and `<e-footer>` regions. Provides the top-level frame for application screens.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Masonry.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Masonry.stories.ts
@@ -18,9 +18,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nPinterest-style multi-column layout that packs items of varying heights without leaving gaps. Configurable column count and inter-item spacing.',
+          'Pinterest-style multi-column layout that packs items of varying heights without leaving gaps. Configurable column count and inter-item spacing.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Space.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Space.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nInline gap utility that distributes equal spacing between children. Lighter than Flex when all you need is a consistent gutter between elements.',
+          'Inline gap utility that distributes equal spacing between children. Lighter than Flex when all you need is a consistent gutter between elements.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Splitter.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Splitter.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nResizable two-pane layout with a draggable divider. Supports horizontal and vertical orientations plus min-size constraints so panes can’t be collapsed past a usable width.',
+          'Resizable two-pane layout with a draggable divider. Supports horizontal and vertical orientations plus min-size constraints so panes can’t be collapsed past a usable width.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/layout/Watermark.stories.ts
+++ b/packages/epaper-components/src/stories/layout/Watermark.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nTiled SVG watermark layered behind slotted content. Designed for print-style "DRAFT" / "CONFIDENTIAL" labels on e-paper layouts.',
+          'Tiled SVG watermark layered behind slotted content. Designed for print-style "DRAFT" / "CONFIDENTIAL" labels on e-paper layouts.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Anchor.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Anchor.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nIn-page navigation that highlights the section currently in view as the user scrolls. Useful for long documentation or article pages.',
+          'In-page navigation that highlights the section currently in view as the user scrolls. Useful for long documentation or article pages.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/BackTop.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/BackTop.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nFloating button that scrolls the window (or a target container) to the top. Hidden until the user has scrolled past `visibility-height`.',
+          'Floating button that scrolls the window (or a target container) to the top. Hidden until the user has scrolled past `visibility-height`.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Breadcrumb.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Breadcrumb.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nHierarchical trail showing the user’s location within nested pages. The last item represents the current page and is rendered as plain text.',
+          'Hierarchical trail showing the user’s location within nested pages. The last item represents the current page and is rendered as plain text.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Dropdown.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Dropdown.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nLightweight menu that opens from a trigger button to expose secondary actions, filters, or sort options. Closes on outside click and Escape.',
+          'Lightweight menu that opens from a trigger button to expose secondary actions, filters, or sort options. Closes on outside click and Escape.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Menu.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Menu.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nNavigation container with vertical or horizontal layout. Items support icons, badges and one level of nested children. The active item is reflected through `aria-current="page"`.',
+          'Navigation container with vertical or horizontal layout. Items support icons, badges and one level of nested children. The active item is reflected through `aria-current="page"`.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Pagination.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Pagination.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nPage-list control for paged data sets. Provides previous/next buttons, direct page jumps and an ellipsis when the page count exceeds the visible window.',
+          'Page-list control for paged data sets. Provides previous/next buttons, direct page jumps and an ellipsis when the page count exceeds the visible window.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Steps.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Steps.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSequential progress indicator for multi-step flows such as onboarding, checkout or wizards. Renders horizontally by default; switch to `vertical` for tall sidebars.',
+          'Sequential progress indicator for multi-step flows such as onboarding, checkout or wizards. Renders horizontally by default; switch to `vertical` for tall sidebars.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Tabs.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Tabs.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nSwitcher between sibling content panes with an underline-style active indicator. Implements WAI-ARIA tabs pattern with full keyboard support (← → Home End).',
+          'Switcher between sibling content panes with an underline-style active indicator. Implements WAI-ARIA tabs pattern with full keyboard support (← → Home End).',
       },
     },
   },

--- a/packages/epaper-components/src/stories/navigation/Toc.stories.ts
+++ b/packages/epaper-components/src/stories/navigation/Toc.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          "**Version:** v1.3.0\n\nAuto-generated table of contents. Scans a document's headings and mirrors them into an `<e-anchor>` it builds itself — no hand-written `<e-anchor-item>` list required.",
+          "Auto-generated table of contents. Scans a document's headings and mirrors them into an `<e-anchor>` it builds itself — no hand-written `<e-anchor-item>` list required.",
       },
     },
   },

--- a/packages/epaper-components/src/stories/primitives/Badge.stories.ts
+++ b/packages/epaper-components/src/stories/primitives/Badge.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nDecorative text label used to mark status, categories or counts. Pure ink — no fill colors, just a flat outlined chip. Use the `inverted` variant for emphasis on light surfaces.',
+          'Decorative text label used to mark status, categories or counts. Pure ink — no fill colors, just a flat outlined chip. Use the `inverted` variant for emphasis on light surfaces.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/primitives/BadgeCount.stories.ts
+++ b/packages/epaper-components/src/stories/primitives/BadgeCount.stories.ts
@@ -6,9 +6,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nCompact numeric indicator for unread or new-item counts. Renders as a small filled chip overflowing past `max` (default 99) or as a simple dot when `dot` is set. Typically overlaid on icons, avatars, or menu items.',
+          'Compact numeric indicator for unread or new-item counts. Renders as a small filled chip overflowing past `max` (default 99) or as a simple dot when `dot` is set. Typically overlaid on icons, avatars, or menu items.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/primitives/Button.stories.ts
+++ b/packages/epaper-components/src/stories/primitives/Button.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nPrimary interactive control for triggering actions. Three visual variants — `primary` (filled ink), `secondary` (outlined), and `destructive` (hatched) — plus a disabled state. Always meets the 44 px hit-target token.',
+          'Primary interactive control for triggering actions. Three visual variants — `primary` (filled ink), `secondary` (outlined), and `destructive` (hatched) — plus a disabled state. Always meets the 44 px hit-target token.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/primitives/Icon.stories.ts
+++ b/packages/epaper-components/src/stories/primitives/Icon.stories.ts
@@ -52,9 +52,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nMonochrome line icon rendered as inline SVG from the built-in icon set. Sized in pixels (default 20) and styled with the current ink color. Provide a `label` whenever the icon is the only thing conveying meaning.',
+          'Monochrome line icon rendered as inline SVG from the built-in icon set. Sized in pixels (default 20) and styled with the current ink color. Provide a `label` whenever the icon is the only thing conveying meaning.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/primitives/Ribbon.stories.ts
+++ b/packages/epaper-components/src/stories/primitives/Ribbon.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nDiagonal corner banner attached to a parent container — typically a card. Used sparingly for promotions, status flags or “new” callouts.',
+          'Diagonal corner banner attached to a parent container — typically a card. Used sparingly for promotions, status flags or “new” callouts.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/typography/Link.stories.ts
+++ b/packages/epaper-components/src/stories/typography/Link.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nInline anchor styled with the system’s underline + ink-fg colour. Set `underline` when you need to force a visible underline outside flowing prose.',
+          'Inline anchor styled with the system’s underline + ink-fg colour. Set `underline` when you need to force a visible underline outside flowing prose.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/typography/Prose.stories.ts
+++ b/packages/epaper-components/src/stories/typography/Prose.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.3.0',
       description: {
         component:
-          '**Version:** v1.3.0\n\nTypographic container for document bodies. Slotted `<h2>`, `<p>`, `<ul>`/`<ol>`, `<blockquote>`, `<figure>` and `<table>` markup is styled through child selectors — the component itself renders nothing.',
+          'Typographic container for document bodies. Slotted `<h2>`, `<p>`, `<ul>`/`<ol>`, `<blockquote>`, `<figure>` and `<table>` markup is styled through child selectors — the component itself renders nothing.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/typography/Text.stories.ts
+++ b/packages/epaper-components/src/stories/typography/Text.stories.ts
@@ -7,9 +7,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nBody-text element bound to the system type scale. Pick a `kind` (`body`, `prose`, `small`, `mono`, `label`) to map onto the matching `--ink-text-*` token and line-height.',
+          'Body-text element bound to the system type scale. Pick a `kind` (`body`, `prose`, `small`, `mono`, `label`) to map onto the matching `--ink-text-*` token and line-height.',
       },
     },
   },

--- a/packages/epaper-components/src/stories/typography/Title.stories.ts
+++ b/packages/epaper-components/src/stories/typography/Title.stories.ts
@@ -8,9 +8,10 @@ const meta: Meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      subtitle: 'Since v1.0.1',
       description: {
         component:
-          '**Version:** v1.0.1\n\nHeading element across the H1–H6 scale. The `level` attribute drives both the rendered tag (for semantics) and the `--ink-text-h*` token used for sizing.',
+          'Heading element across the H1–H6 scale. The `level` attribute drives both the rendered tag (for semantics) and the `--ink-text-h*` token used for sizing.',
       },
     },
   },


### PR DESCRIPTION
## Summary

- [x] Changes are scoped (no unrelated files touched)
- [x] Demo/story/docs updated if needed
- [x] CSS output builds locally (`npm run build`)

Fixes two Storybook-only issues reported against the deployed docs
(per-components.dev):

1. **Homepage markdown not rendering correctly.** The Introduction page's
   markdown tables (the rules/state tables) rendered as a flat run of
   pipe-separated text instead of actual `<table>`s. `@storybook/addon-docs`'
   MDX compiler doesn't enable GitHub-Flavored Markdown by default —
   `remark-gfm` is now wired into `.storybook/main.ts`'s `addon-docs` options.

2. **Version marker didn't read as a tag.** Every autodoc'd component
   embedded `**Version:** vX.Y.Z` as the first line of its docs description —
   unstyled bold text with no visual separation from the prose, easy to read
   as a version scoped to that one component rather than the library's
   release. The version is now set via `parameters.docs.subtitle` ("Since
   vX.Y.Z") across all 85 component stories, and restyled (new
   `apps/storybook/.storybook/docs.css`) as a small bordered tag matching the
   library's own `.ink-tag` look.

## Testing

- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run build`
- Verified visually in a local Storybook run (Introduction page tables now
  render as real tables; a component doc page — `Display/Price` — shows
  "SINCE V1.3.0" as a closed, correctly-sized bordered tag above the
  description).

## Notes

- `docs.css` only targets `.sbdocs-subtitle` (Storybook's own docs chrome),
  not the shipped library styles — no change to `tokens.css`/`base.css`/
  `components.css`.
- The rule needs `!important` on every property: addon-docs' default
  Subtitle styling is injected via a runtime `<style>` tag that lands after
  this stylesheet in the cascade, so without it the two rules blended into
  an open-bottomed border with oversized text.
- Added a `CHANGELOG.md` entry under `Unreleased → Fixed`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L5rsafXzozTkTiTfcviYGm)_